### PR TITLE
cli.ts: add Apple Silicon homebrew path

### DIFF
--- a/electron/cli.ts
+++ b/electron/cli.ts
@@ -17,7 +17,7 @@ enum BrewCLICommands { // TODO moved from src
   OPEN_LOGS = 'OPEN_LOGS',
 }
 
-const PATH_ENV = `${process.env.PATH}:/bin/sh:/usr/local/bin`
+const PATH_ENV = `${process.env.PATH}:/bin/sh:/usr/local/bin:/opt/homebrew/bin`
 log('[DEBUG] PATH: ' + PATH_ENV);
 
 export const execWrapper = async (command: string): Promise<string> => {


### PR DESCRIPTION
Add Apple Silicon default installation path /opt/homebrew See https://docs.brew.sh/Installation for more information.

Resolves #131

Please ensure your pull request adheres to the following guidelines:

- [ ] Use the following format: `* [owner/repo](link)`
- [ ] Link additions should be added to the bottom of the relevant category.
- [ ] New categories or improvements to the existing categorization are welcome.
- [ ] Search previous suggestions before making a new one, as yours may be a duplicate.
- [ ] Sort by alphabetical order

Thanks for contributing!
