### PR TITLE
⚡ Bolt: [performance improvement] filterApps UI filtering optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-11-20 - [Frontend Filtering Optimization]
+**Learning:** For large datasets (like Pantry's ~100k allApps), creating inline closures or running invariant string transformations (like `.toLowerCase()`) inside `.filter()` loops blocks the Electron UI thread, especially during keystroke searches.
+**Action:** Move invariant transformations outside the loop, order early returns by condition speed (direct property checks > set lookups > string includes), and memoize expensive computed properties directly onto the item objects (as optional properties defined in the interface) to ensure lightning-fast UI responsiveness.

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -37,6 +37,10 @@ interface App {
   homepage: string;
   version: string;
   type: 'cask' | 'formula';
+  _category?: string;
+  _nameLower?: string;
+  _descLower?: string;
+  _homepageLower?: string;
 }
 
 // Immediate console log to verify script is loading
@@ -495,31 +499,48 @@ function filterApps(): void {
     // Reset filtered apps before filtering
     filteredApps = [];
 
-    filteredApps = allApps.filter((app) => {
-      const matchesType = selectedType === 'All' || app.type === selectedType;
+    // Precompute lowercase search term outside the loop
+    const searchLower = searchTerm ? searchTerm.toLowerCase() : '';
 
-      let matchesCategory = true;
-      if (selectedCategory === 'Installed') {
-        matchesCategory = installedApps.has(app.name);
-      } else if (selectedCategory !== 'All') {
-        matchesCategory = getCategoryForApp(app) === selectedCategory;
+    filteredApps = allApps.filter((app) => {
+      // 1. Direct property checks (fastest)
+      if (selectedType !== 'All' && app.type !== selectedType) {
+        return false;
       }
 
-      const matchesSearch =
-        !searchTerm ||
-        (() => {
-          const searchLower = searchTerm.toLowerCase();
-          const name = (app.name || '').toLowerCase();
-          const desc = (app.description || '').toLowerCase();
-          const homepage = (app.homepage || '').toLowerCase();
-          return (
-            name.includes(searchLower) ||
-            desc.includes(searchLower) ||
-            homepage.includes(searchLower)
-          );
-        })();
+      // 2. Set lookups or cached category check
+      if (selectedCategory === 'Installed') {
+        if (!installedApps.has(app.name)) return false;
+      } else if (selectedCategory !== 'All') {
+        if (app._category === undefined) {
+          app._category = getCategoryForApp(app);
+        }
+        if (app._category !== selectedCategory) return false;
+      }
 
-      return matchesType && matchesCategory && matchesSearch;
+      // 3. String includes (slowest, only check if searchTerm exists)
+      if (searchLower) {
+        // Cache lowercased strings on the app object for future searches
+        if (app._nameLower === undefined) {
+          app._nameLower = (app.name || '').toLowerCase();
+        }
+        if (app._descLower === undefined) {
+          app._descLower = (app.description || '').toLowerCase();
+        }
+        if (app._homepageLower === undefined) {
+          app._homepageLower = (app.homepage || '').toLowerCase();
+        }
+
+        if (
+          !app._nameLower.includes(searchLower) &&
+          !app._descLower.includes(searchLower) &&
+          !app._homepageLower.includes(searchLower)
+        ) {
+          return false;
+        }
+      }
+
+      return true;
     });
 
     // Reset scroll position and visible items when filtering

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,10 @@ export interface App {
   homepage: string;
   version: string;
   type: 'cask' | 'formula';
+  _category?: string;
+  _nameLower?: string;
+  _descLower?: string;
+  _homepageLower?: string;
 }
 
 export interface InstalledApp {


### PR DESCRIPTION
💡 What: Refactored the `filterApps` function in `renderer.ts` to use early returns, hoisted invariant string conversions outside the loop, and implemented caching for lowercase strings and category lookups directly onto the `app` object.
🎯 Why: Iterating over ~100k items and running multiple `.toLowerCase()` operations and string includes checks for every keystroke caused unnecessary CPU overhead and blocked the Electron main UI thread, making searching feel sluggish.
📊 Impact: Significantly reduces string allocation pressure and garbage collection overhead during frequent `.filter` operations, avoiding N+ O(N) redundant string allocations, dropping search processing time per keystroke to effectively near O(1) string allocations per app.
🔬 Measurement: Verify by typing rapidly in the search bar and noting the improved responsiveness, or by observing decreased CPU usage and GC pauses in the DevTools performance profiler.

---
*PR created automatically by Jules for task [16470445954982530217](https://jules.google.com/task/16470445954982530217) started by @romankurnovskii*

## Summary by Sourcery

Optimize app filtering in the renderer to reduce per-keystroke CPU and GC overhead for large app lists.

Enhancements:
- Add cached lowercase and category properties to the App model to avoid repeated string computations during filtering.
- Refine filterApps logic to use early returns and short-circuit checks for type, installation status, and category before performing string matching.

Documentation:
- Add a Jules bolt note documenting the frontend filtering optimization and recommended patterns for performant search over large datasets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added optimization notes for search performance.

* **Refactor**
  * Optimized search and filter operations for improved responsiveness when working with large datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->