### PR TITLE
feat(renderer): add sidebar detail panel for applications

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -73,6 +73,37 @@
       </div>
     </div>
 
+    <!-- App Detail Sidebar -->
+    <div class="sidebar-overlay" id="sidebarOverlay"></div>
+    <div class="app-sidebar" id="appSidebar">
+      <div class="sidebar-header">
+        <h2 class="sidebar-title" id="sidebarTitle">App Name</h2>
+        <button class="sidebar-close" id="sidebarClose">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+        </button>
+      </div>
+      <div class="sidebar-content">
+        <div class="sidebar-meta">
+          <span class="sidebar-version" id="sidebarVersion">v1.0.0</span>
+          <span class="sidebar-type" id="sidebarType">cask</span>
+        </div>
+        <p class="sidebar-description" id="sidebarDescription">Description goes here</p>
+        <a href="#" target="_blank" class="sidebar-link" id="sidebarHomepage">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+            <polyline points="15 3 21 3 21 9"></polyline>
+            <line x1="10" y1="14" x2="21" y2="3"></line>
+          </svg>
+          Open Homepage
+        </a>
+      </div>
+      <div class="sidebar-actions" id="sidebarActions">
+      </div>
+    </div>
+
     <!-- Terminal -->
     <div class="terminal-container" id="terminalContainer">
       <div class="terminal-header">

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -84,6 +84,17 @@ let appCount: HTMLElement;
 let loadingMessage: HTMLElement;
 let logPath: HTMLElement;
 
+// Sidebar elements
+let sidebarOverlay: HTMLElement;
+let appSidebar: HTMLElement;
+let sidebarTitle: HTMLElement;
+let sidebarVersion: HTMLElement;
+let sidebarType: HTMLElement;
+let sidebarDescription: HTMLElement;
+let sidebarHomepage: HTMLAnchorElement;
+let sidebarActions: HTMLElement;
+let sidebarClose: HTMLButtonElement;
+
 // Initialize
 function init(): void {
   // Get DOM elements
@@ -98,6 +109,16 @@ function init(): void {
   appCount = document.getElementById('appCount') as HTMLElement;
   loadingMessage = document.getElementById('loadingMessage') as HTMLElement;
   logPath = document.getElementById('logPath') as HTMLElement;
+  
+  sidebarOverlay = document.getElementById('sidebarOverlay') as HTMLElement;
+  appSidebar = document.getElementById('appSidebar') as HTMLElement;
+  sidebarTitle = document.getElementById('sidebarTitle') as HTMLElement;
+  sidebarVersion = document.getElementById('sidebarVersion') as HTMLElement;
+  sidebarType = document.getElementById('sidebarType') as HTMLElement;
+  sidebarDescription = document.getElementById('sidebarDescription') as HTMLElement;
+  sidebarHomepage = document.getElementById('sidebarHomepage') as HTMLAnchorElement;
+  sidebarActions = document.getElementById('sidebarActions') as HTMLElement;
+  sidebarClose = document.getElementById('sidebarClose') as HTMLButtonElement;
 
   const versionInfo = document.getElementById('versionInfo') as HTMLElement;
 
@@ -217,6 +238,13 @@ function setupEventListeners(): void {
   terminalToggle.addEventListener('click', (e) => {
     e.stopPropagation();
     toggleTerminal();
+  });
+
+  // Sidebar listeners
+  sidebarClose.addEventListener('click', closeSidebar);
+  sidebarOverlay.addEventListener('click', closeSidebar);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') closeSidebar();
   });
 
   // IPC listeners
@@ -578,6 +606,17 @@ function renderApps(): void {
     </div>
   `;
 
+  appsGrid.querySelectorAll('.app-card').forEach((card) => {
+    card.addEventListener('click', () => {
+      const btn = card.querySelector('.app-button') as HTMLElement;
+      if (btn && btn.dataset.app) {
+        const appName = btn.dataset.app;
+        const app = filteredApps.find(a => a.name === appName);
+        if (app) openAppDetail(app);
+      }
+    });
+  });
+
   appsGrid.querySelectorAll('.app-button').forEach((btn) => {
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
@@ -643,6 +682,60 @@ function renderAppCard(app: App, isInstalled: boolean): string {
       </div>
     </div>
   `;
+}
+
+function openAppDetail(app: App): void {
+  const isInstalled = installedApps.has(app.name);
+  
+  sidebarTitle.textContent = app.name;
+  sidebarVersion.textContent = `v${app.version || 'N/A'}`;
+  sidebarType.textContent = app.type;
+  sidebarDescription.textContent = app.description || 'No description available.';
+  
+  if (app.homepage) {
+    sidebarHomepage.href = app.homepage;
+    sidebarHomepage.style.display = 'inline-flex';
+  } else {
+    sidebarHomepage.style.display = 'none';
+  }
+
+  sidebarActions.innerHTML = `
+    <button class="app-button ${isInstalled ? 'installed' : ''}" 
+            data-app="${app.name}" 
+            data-type="${app.type}"
+            style="width: 100%">
+      ${isInstalled ? 'Delete' : 'Install'}
+    </button>
+  `;
+
+  const actionBtn = sidebarActions.querySelector('.app-button');
+  if (actionBtn) {
+    actionBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const appName = (actionBtn as HTMLElement).dataset.app;
+      const appType = (actionBtn as HTMLElement).dataset.type;
+      if (!appName || !appType) return;
+
+      if (isInstalled) {
+        ipcRenderer.send('uninstall-app', appName, appType);
+      } else {
+        ipcRenderer.send('install-app', appName, appType);
+      }
+      
+      closeSidebar();
+      if (!terminalVisible) {
+        toggleTerminal();
+      }
+    });
+  }
+
+  appSidebar.classList.add('visible');
+  sidebarOverlay.classList.add('visible');
+}
+
+function closeSidebar(): void {
+  appSidebar.classList.remove('visible');
+  sidebarOverlay.classList.remove('visible');
 }
 
 function toggleTerminal(): void {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -399,6 +399,149 @@ body {
   margin-right: 8px;
 }
 
+/* App Detail Sidebar */
+.sidebar-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  z-index: 90;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.sidebar-overlay.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.app-sidebar {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 400px;
+  max-width: 100vw;
+  background: rgba(25, 18, 43, 0.95);
+  backdrop-filter: blur(24px);
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: -10px 0 30px rgba(0, 0, 0, 0.5);
+  z-index: 100;
+  transform: translateX(100%);
+  transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  display: flex;
+  flex-direction: column;
+}
+
+.app-sidebar.visible {
+  transform: translateX(0);
+}
+
+.sidebar-header {
+  padding: 24px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.sidebar-title {
+  font-size: 24px;
+  font-weight: bold;
+  color: #fff;
+  margin: 0;
+}
+
+.sidebar-close {
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.2s;
+}
+
+.sidebar-close:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.sidebar-content {
+  padding: 24px;
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.sidebar-meta {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.sidebar-version {
+  font-size: 14px;
+  font-weight: 500;
+  background: rgba(193, 182, 255, 0.2);
+  color: #c1b6ff;
+  padding: 6px 12px;
+  border-radius: 9999px;
+}
+
+.sidebar-type {
+  font-size: 14px;
+  font-weight: 500;
+  color: #9ca3af;
+  text-transform: capitalize;
+}
+
+.sidebar-description {
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.sidebar-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #63ffd2;
+  text-decoration: none;
+  font-size: 15px;
+  padding: 10px 16px;
+  background: rgba(99, 255, 210, 0.1);
+  border-radius: 8px;
+  width: fit-content;
+  transition: all 0.2s;
+}
+
+.sidebar-link:hover {
+  background: rgba(99, 255, 210, 0.2);
+}
+
+.sidebar-actions {
+  padding: 24px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  gap: 16px;
+}
+
+.sidebar-actions .app-button {
+  padding: 14px 24px;
+  font-size: 16px;
+  font-weight: 600;
+}
+
 /* Terminal */
 .terminal-container {
   flex-shrink: 0;


### PR DESCRIPTION
This PR implements the top-priority competitor feature identified from brew-browser: a modern, beautiful slide-in sidebar providing deep app metadata, version information, homepage links, and installation/removal actions directly inside the app view.

## Summary by Sourcery

Add an interactive application detail sidebar to the renderer UI with rich metadata and inline install/uninstall actions.

New Features:
- Introduce a slide-in app detail sidebar showing name, version, type, description, and homepage link for the selected application.
- Enable opening the app detail sidebar by clicking an app card and closing it via close button, backdrop click, or Escape key.
- Allow installing or uninstalling the selected application directly from the sidebar while automatically toggling the terminal view.
- Add styling for the sidebar overlay, panel, content, and actions to visually integrate with the existing renderer layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an app detail sidebar that displays when clicking on an app card
  * Sidebar displays app metadata including version, type, description, and homepage link
  * Sidebar includes an action button for installing or uninstalling the app based on current state
  * Sidebar can be closed via the close button, overlay click, or Escape key

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/romankurnovskii/BrewMate/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->