### PR TITLE
⚡ Bolt: Replace O(N) array scans with O(1) Map lookups for performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,6 @@
 ## 2024-05-24 - Async Cache I/O
 **Learning:** For Electron apps handling large JSON payloads (like 100k items from the Homebrew API), using synchronous file system operations (`fs.readFileSync` and `fs.writeFileSync`) blocks the main thread.
 **Action:** When performing file I/O for large data, always use asynchronous file system methods (`fs.promises`) to avoid blocking the event loop and maintain UI responsiveness.
+## 2026-06-05 - Optimized application lookups with O(1) Maps
+**Learning:** When cross-referencing subsets (like `installedApps`) against massive datasets (like `allApps` ~100k items) in the renderer, using nested array scans like `.find()` causes severe UI blocking due to O(N) complexity per lookup.
+**Action:** Precompute and maintain a `Map<string, App>` alongside the main data array to enable O(1) property lookups, eliminating redundant array iterations.

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1,10 +1,7 @@
 // Uses window.electronAPI exposed via contextBridge
 
 // Inline constants to avoid CommonJS exports issue
-let CATEGORIES = [
-  'All',
-  'Installed',
-];
+let CATEGORIES = ['All', 'Installed'];
 
 interface CategoryData {
   categories: Record<string, { label: string; color: string; keywords?: string[] }>;
@@ -13,7 +10,6 @@ interface CategoryData {
 }
 
 let categoryDictionary: CategoryData | null = null;
-
 
 const VIRTUAL_SCROLL_CONFIG = {
   rowHeight: 220,
@@ -44,6 +40,7 @@ console.log('[Renderer] ipcRenderer loaded:', !!ipcRenderer);
 
 // State
 let allApps: Array<App> = [];
+let allAppsMap = new Map<string, App>(); // Optimization: O(1) lookups for 100k items
 let installedApps = new Set<string>();
 let filteredApps: Array<App> = [];
 let selectedCategory = 'All';
@@ -157,9 +154,11 @@ function init(): void {
   appCount = document.getElementById('appCount') as HTMLElement;
   loadingMessage = document.getElementById('loadingMessage') as HTMLElement;
   logPath = document.getElementById('logPath') as HTMLElement;
-  terminalHistorySelect = document.getElementById('terminalHistorySelect') as HTMLSelectElement;
+  terminalHistorySelect = document.getElementById(
+    'terminalHistorySelect'
+  ) as HTMLSelectElement;
   trendingToggleBtn = document.getElementById('trendingToggleBtn') as HTMLButtonElement;
-  
+
   sidebarOverlay = document.getElementById('sidebarOverlay') as HTMLElement;
   appSidebar = document.getElementById('appSidebar') as HTMLElement;
   sidebarTitle = document.getElementById('sidebarTitle') as HTMLElement;
@@ -178,8 +177,12 @@ function init(): void {
   sidebarVulnRow = document.getElementById('sidebarVulnRow') as HTMLElement;
   sidebarVulns = document.getElementById('sidebarVulns') as HTMLElement;
 
-  navButtons = document.querySelectorAll('.nav-sidebar .nav-button') as NodeListOf<HTMLButtonElement>;
-  tabViews = document.querySelectorAll('.main-layout-wrapper .tab-view') as NodeListOf<HTMLElement>;
+  navButtons = document.querySelectorAll(
+    '.nav-sidebar .nav-button'
+  ) as NodeListOf<HTMLButtonElement>;
+  tabViews = document.querySelectorAll(
+    '.main-layout-wrapper .tab-view'
+  ) as NodeListOf<HTMLElement>;
 
   dashInstalledCount = document.getElementById('dashInstalledCount') as HTMLElement;
   dashCaskCount = document.getElementById('dashCaskCount') as HTMLElement;
@@ -307,12 +310,16 @@ function setupEventListeners(): void {
   // Type filter buttons
   typeFilter.querySelectorAll('.type-toggle').forEach((btn) => {
     btn.addEventListener('click', () => {
-      selectedType = (btn as HTMLElement).dataset.type as 'All' | 'cask' | 'formula' | 'trending';
+      selectedType = (btn as HTMLElement).dataset.type as
+        | 'All'
+        | 'cask'
+        | 'formula'
+        | 'trending';
       document.querySelectorAll('.type-toggle').forEach((b) => b.classList.remove('active'));
       btn.classList.add('active');
       visibleStartIndex = 0;
       appsGrid.scrollTop = 0;
-      
+
       if (selectedType === 'trending' && trendingApps.size === 0) {
         // Fetch trending apps if we don't have them
         ipcRenderer.send('get-trending-apps');
@@ -366,11 +373,13 @@ function setupEventListeners(): void {
   });
   ipcRenderer.on('all-apps', (_event: any, apps: Array<App>) => {
     console.log('[Renderer] Received all-apps:', apps.length);
+    allAppsMap.clear();
     for (const app of apps) {
       app._nameLower = (app.name || '').toLowerCase();
       app._descLower = (app.description || '').toLowerCase();
       app._homeLower = (app.homepage || '').toLowerCase();
       app._category = getCategoryForApp(app);
+      allAppsMap.set(app.name, app);
     }
     allApps = apps;
     isLoading = false;
@@ -441,11 +450,13 @@ function setupEventListeners(): void {
     }
   );
   ipcRenderer.on('all-apps-updated', (_event: any, apps: Array<App>) => {
+    allAppsMap.clear();
     for (const app of apps) {
       app._nameLower = (app.name || '').toLowerCase();
       app._descLower = (app.description || '').toLowerCase();
       app._homeLower = (app.homepage || '').toLowerCase();
       app._category = getCategoryForApp(app);
+      allAppsMap.set(app.name, app);
     }
     allApps = apps;
     isLoading = false;
@@ -496,7 +507,7 @@ function setupEventListeners(): void {
     if (details) {
       // popuplate size, dependencies, stars
       sidebarSize.textContent = details.size || 'Unknown';
-      
+
       const deps = details.dependencies || [];
       if (deps.length > 0) {
         sidebarDependencies.innerHTML = deps.join(', ');
@@ -536,7 +547,7 @@ function setupEventListeners(): void {
         dashScanVulnBtn.disabled = false;
       }, 3000);
     }
-    
+
     // Log results in the terminal activity drawer
     if (!terminalVisible) toggleTerminal();
     terminalOutput.insertAdjacentHTML(
@@ -562,7 +573,7 @@ function setupEventListeners(): void {
     btn.addEventListener('click', () => {
       const view = btn.dataset.view as 'dashboard' | 'explore' | 'updates' | 'services';
       if (!view) return;
-      
+
       activeView = view;
       navButtons.forEach((b) => b.classList.remove('active'));
       btn.classList.add('active');
@@ -600,7 +611,9 @@ function setupEventListeners(): void {
 
   if (dashViewUpdatesBtn) {
     dashViewUpdatesBtn.addEventListener('click', () => {
-      const updatesBtn = document.querySelector('.nav-button[data-view="updates"]') as HTMLButtonElement;
+      const updatesBtn = document.querySelector(
+        '.nav-button[data-view="updates"]'
+      ) as HTMLButtonElement;
       if (updatesBtn) updatesBtn.click();
     });
   }
@@ -654,19 +667,22 @@ function setupEventListeners(): void {
   });
 
   // Upgrade individual app complete listener
-  ipcRenderer.on('upgrade-complete', (_event: any, { appName, success }: { appName: string; success: boolean }) => {
-    console.log('[Renderer] Upgrade complete:', appName, success);
-    if (success) {
-      // Optimistically remove from list
-      outdatedApps = outdatedApps.filter(app => app.name !== appName);
-      updateUpdatesBadge();
-      if (activeView === 'dashboard') {
-        updateDashboardView();
-      } else if (activeView === 'updates') {
-        renderUpdatesView();
+  ipcRenderer.on(
+    'upgrade-complete',
+    (_event: any, { appName, success }: { appName: string; success: boolean }) => {
+      console.log('[Renderer] Upgrade complete:', appName, success);
+      if (success) {
+        // Optimistically remove from list
+        outdatedApps = outdatedApps.filter((app) => app.name !== appName);
+        updateUpdatesBadge();
+        if (activeView === 'dashboard') {
+          updateDashboardView();
+        } else if (activeView === 'updates') {
+          renderUpdatesView();
+        }
       }
     }
-  });
+  );
 
   // Services listeners
   ipcRenderer.on('brew-services-list', (_event: any, services: any[]) => {
@@ -674,15 +690,18 @@ function setupEventListeners(): void {
     renderServices(services);
   });
 
-  ipcRenderer.on('service-action-complete', (_event: any, { action, service, success, error }: any) => {
-    console.log('[Renderer] Service action complete:', action, service, success, error);
-    if (success) {
-      ipcRenderer.send('get-brew-services');
-    } else {
-      alert(`Failed to ${action} ${service}: ${error}`);
-      ipcRenderer.send('get-brew-services');
+  ipcRenderer.on(
+    'service-action-complete',
+    (_event: any, { action, service, success, error }: any) => {
+      console.log('[Renderer] Service action complete:', action, service, success, error);
+      if (success) {
+        ipcRenderer.send('get-brew-services');
+      } else {
+        alert(`Failed to ${action} ${service}: ${error}`);
+        ipcRenderer.send('get-brew-services');
+      }
     }
-  });
+  );
 
   // Upgrade all complete listener
   ipcRenderer.on('upgrade-all-complete', (_event: any, { success }: { success: boolean }) => {
@@ -757,24 +776,25 @@ function renderCategories(): void {
 
 function getCategoryForApp(app: App): string {
   if (categoryDictionary) {
-    const categoryId = app.type === 'cask' 
-      ? categoryDictionary.casks[app.name] 
-      : categoryDictionary.formulae[app.name];
-    
+    const categoryId =
+      app.type === 'cask'
+        ? categoryDictionary.casks[app.name]
+        : categoryDictionary.formulae[app.name];
+
     if (categoryId && categoryDictionary.categories[categoryId]) {
       return categoryDictionary.categories[categoryId].label;
     }
 
     const searchStr = `${app.name} ${app.description || ''}`.toLowerCase();
-    
+
     // Dynamic fallback using keywords defined in categories.json
     for (const cat of Object.values(categoryDictionary.categories)) {
-      if (cat.keywords && cat.keywords.some(kw => searchStr.includes(kw))) {
+      if (cat.keywords && cat.keywords.some((kw) => searchStr.includes(kw))) {
         return cat.label;
       }
     }
   }
-  
+
   return 'Other';
 }
 
@@ -788,7 +808,7 @@ function renderDashboardDonutChart(): void {
   let totalCount = 0;
 
   for (const appName of installedApps) {
-    const app = allApps.find((a) => a.name === appName);
+    const app = allAppsMap.get(appName); // Optimization: O(1) lookup instead of O(N)
     if (app) {
       const category = app._category || getCategoryForApp(app);
       categoryCounts[category] = (categoryCounts[category] || 0) + 1;
@@ -808,7 +828,7 @@ function renderDashboardDonutChart(): void {
     .filter(([name]) => name !== 'Other');
 
   let otherCount = categoryCounts['Other'] || 0;
-  
+
   if (sortedCategories.length > 7) {
     const tail = sortedCategories.slice(7);
     sortedCategories = sortedCategories.slice(0, 7);
@@ -824,7 +844,7 @@ function renderDashboardDonutChart(): void {
   // Build SVG and Legend
   let svgContent = '';
   let legendContent = '';
-  
+
   let cumulativePercentage = 0;
   const radius = 46;
   const circumference = 2 * Math.PI * radius;
@@ -832,7 +852,7 @@ function renderDashboardDonutChart(): void {
   // Define colors if missing
   const getCategoryColor = (label: string) => {
     if (label === 'Other') return 'hsl(215, 16%, 47%)';
-    const entry = Object.values(categoryDictionary!.categories).find(c => c.label === label);
+    const entry = Object.values(categoryDictionary!.categories).find((c) => c.label === label);
     return entry ? entry.color : 'hsl(200, 10%, 50%)';
   };
 
@@ -843,7 +863,7 @@ function renderDashboardDonutChart(): void {
     const color = getCategoryColor(label);
 
     svgContent += `<circle class="donut-segment" data-category="${label}" cx="50" cy="50" r="${radius}" fill="transparent" stroke="${color}" stroke-width="8" stroke-dasharray="${strokeDashArray}" stroke-dashoffset="${strokeDashOffset}" transform="rotate(-90 50 50)"></circle>`;
-    
+
     legendContent += `
       <div class="donut-legend-item" data-category="${label}">
         <span class="donut-legend-dot" style="background-color: ${color}"></span>
@@ -886,10 +906,10 @@ function renderDashboardDonutChart(): void {
 
   const navigateToCategory = (cat: string) => {
     // Switch to Explore view and filter by category
-    const exploreBtn = Array.from(navButtons).find(btn => btn.dataset.view === 'explore');
+    const exploreBtn = Array.from(navButtons).find((btn) => btn.dataset.view === 'explore');
     if (exploreBtn) {
       exploreBtn.click();
-      
+
       // Select category chip
       const chips = categoryChips.querySelectorAll('.category-chip');
       chips.forEach((chip) => {
@@ -934,10 +954,10 @@ function filterApps(): void {
 
     filteredApps = allApps.filter((app) => {
       if (selectedType === 'trending') {
-          if (!trendingApps.has(app.name.toLowerCase())) return false;
-        } else if (selectedType !== 'All' && app.type !== selectedType) {
-          return false;
-        }
+        if (!trendingApps.has(app.name.toLowerCase())) return false;
+      } else if (selectedType !== 'All' && app.type !== selectedType) {
+        return false;
+      }
 
       if (selectedCategory === 'Installed') {
         if (!installedApps.has(app.name)) return false;
@@ -1057,7 +1077,7 @@ function renderApps(): void {
       const btn = card.querySelector('.app-button') as HTMLElement;
       if (btn && btn.dataset.app) {
         const appName = btn.dataset.app;
-        const app = filteredApps.find(a => a.name === appName);
+        const app = allAppsMap.get(appName); // Optimization: O(1) lookup instead of O(N)
         if (app) openAppDetail(app);
       }
     });
@@ -1132,12 +1152,12 @@ function renderAppCard(app: App, isInstalled: boolean): string {
 
 function openAppDetail(app: App): void {
   const isInstalled = installedApps.has(app.name);
-  
+
   sidebarTitle.textContent = app.name;
   sidebarVersion.textContent = `v${app.version || 'N/A'}`;
   sidebarType.textContent = app.type;
   sidebarDescription.textContent = app.description || 'No description available.';
-  
+
   if (app.homepage) {
     sidebarHomepage.href = app.homepage;
     sidebarHomepage.style.display = 'inline-flex';
@@ -1167,7 +1187,7 @@ function openAppDetail(app: App): void {
       } else {
         ipcRenderer.send('install-app', appName, appType);
       }
-      
+
       closeSidebar();
       if (!terminalVisible) {
         toggleTerminal();
@@ -1182,7 +1202,7 @@ function openAppDetail(app: App): void {
   sidebarExtendedDetails.style.display = 'none';
   sidebarDetailsLoader.style.display = 'flex';
   sidebarVulnRow.style.display = 'none'; // Will update if we have full vuln state
-  
+
   ipcRenderer.send('get-app-details', app.name, app.type);
 }
 
@@ -1261,7 +1281,7 @@ function updateDashboardView(): void {
   let caskCount = 0;
   let formulaCount = 0;
   for (const appName of installedApps) {
-    const app = allApps.find((a) => a.name === appName);
+    const app = allAppsMap.get(appName); // Optimization: O(1) lookup instead of O(N)
     if (app) {
       if (app.type === 'cask') {
         caskCount++;
@@ -1309,7 +1329,7 @@ function updateDashboardView(): void {
 
 function renderUpdatesView(): void {
   const updatesCount = outdatedApps.length;
-  
+
   if (updatesUpgradeAllBtn) {
     updatesUpgradeAllBtn.style.display = updatesCount > 0 ? 'inline-flex' : 'none';
   }
@@ -1402,24 +1422,27 @@ function upgradeApp(name: string, type: string): void {
 
 function renderServices(services: any[]): void {
   servicesLoading.style.display = 'none';
-  
+
   if (!services || services.length === 0) {
     servicesEmptyState.style.display = 'flex';
     servicesTable.style.display = 'none';
     return;
   }
-  
+
   servicesEmptyState.style.display = 'none';
   servicesTable.style.display = 'table';
   servicesTableBody.innerHTML = '';
-  
+
   services.forEach((service) => {
     const tr = document.createElement('tr');
-    
+
     // Status badge class
     let statusClass = 'status-stopped';
     let statusText = 'Stopped';
-    if (service.status.toLowerCase() === 'started' || service.status.toLowerCase() === 'running') {
+    if (
+      service.status.toLowerCase() === 'started' ||
+      service.status.toLowerCase() === 'running'
+    ) {
       statusClass = 'status-started';
       statusText = 'Started';
     } else if (service.status.toLowerCase() === 'error') {
@@ -1429,7 +1452,7 @@ function renderServices(services: any[]): void {
       statusClass = 'status-stopped';
       statusText = 'None';
     }
-    
+
     tr.innerHTML = `
       <td>
         <div class="services-name">${escapeHtml(service.name)}</div>
@@ -1455,16 +1478,16 @@ function renderServices(services: any[]): void {
         </button>
       </td>
     `;
-    
+
     servicesTableBody.appendChild(tr);
   });
-  
+
   // Attach event listeners
   const startBtns = servicesTableBody.querySelectorAll('.start-btn');
   const stopBtns = servicesTableBody.querySelectorAll('.stop-btn');
   const restartBtns = servicesTableBody.querySelectorAll('.restart-btn');
-  
-  startBtns.forEach(btn => {
+
+  startBtns.forEach((btn) => {
     btn.addEventListener('click', (e) => {
       const target = e.currentTarget as HTMLButtonElement;
       const serviceName = target.dataset.service;
@@ -1474,8 +1497,8 @@ function renderServices(services: any[]): void {
       }
     });
   });
-  
-  stopBtns.forEach(btn => {
+
+  stopBtns.forEach((btn) => {
     btn.addEventListener('click', (e) => {
       const target = e.currentTarget as HTMLButtonElement;
       const serviceName = target.dataset.service;
@@ -1485,8 +1508,8 @@ function renderServices(services: any[]): void {
       }
     });
   });
-  
-  restartBtns.forEach(btn => {
+
+  restartBtns.forEach((btn) => {
     btn.addEventListener('click', (e) => {
       const target = e.currentTarget as HTMLButtonElement;
       const serviceName = target.dataset.service;
@@ -1509,7 +1532,7 @@ if (document.readyState === 'loading') {
       ipcRenderer.send('get-log-path');
     }
     init();
-    
+
     // Auto-poll for updates
     setInterval(() => {
       if (ipcRenderer) {
@@ -1525,7 +1548,7 @@ if (document.readyState === 'loading') {
     ipcRenderer.send('get-log-path');
   }
   init();
-  
+
   // Auto-poll for updates
   setInterval(() => {
     if (ipcRenderer) {


### PR DESCRIPTION
💡 **What:** Replaced `Array.find()` with `Map.get()` for `allApps` lookups inside `renderer.ts`.
🎯 **Why:** To eliminate severe UI blocking when the app computes stats or interacts with components that require matching `appName` against the `100k` apps dataset.
📊 **Impact:** Reduces lookup time per app from `O(N)` (up to 100,000 array scans per installed app) down to `O(1)`. Overall computation time complexity is reduced from `O(N*M)` to `O(M)`.
🔬 **Measurement:** Open Dashboard view or click any App detail view; UI will render and update instantly without noticeable thread-blocking hitches.

---
*PR created automatically by Jules for task [2691485576494110163](https://jules.google.com/task/2691485576494110163) started by @romankurnovskii*

## Summary by Sourcery

Optimize renderer app lookups and update documentation with performance learnings

Enhancements:
- Maintain a Map of apps alongside the allApps array to enable O(1) lookups by app name in the renderer.
- Use the new Map for installed and filtered app lookups in dashboard rendering and app detail navigation to reduce UI blocking.
- Apply minor formatting and readability improvements in renderer.ts.

Documentation:
- Document the Map-based lookup optimization and associated performance learnings in the Bolt engineering notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized app data lookup performance throughout the application, resulting in faster navigation, dashboard rendering, and overall improved responsiveness of the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->