### PR TITLE
[Bug] Fix 0 apps shown on first init with retry support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ yarn-error.log*
 .continue/
 .vscode/
 docs/
-.dev/AGENTS.md
+.dev/
+AGENTS.md

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -21,11 +21,13 @@ const validReceiveChannels = [
   'toggle-terminal',
   'terminal-output',
   'all-apps',
+  'all-apps-error',
+  'all-apps-updated',
   'installed-apps',
+  'installed-apps-error',
   'install-complete',
   'uninstall-complete',
   'loading-status',
-  'all-apps-updated',
   'terminal-prompt-info',
   'log-path',
   'version-info',
@@ -35,6 +37,10 @@ const validReceiveChannels = [
   'upgrade-all-complete',
   'brew-services-list',
   'service-action-complete',
+  'app-details',
+  'asset-path',
+  'trending-apps-result',
+  'vulnerabilities-result',
 ];
 
 contextBridge.exposeInMainWorld('electronAPI', {

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -53,6 +53,7 @@ let terminalVisible = false;
 let commandToRun: string | null = null;
 let isLoading = true;
 let terminalPrompt = 'user@brewmate ~ %';
+let loadError: string | null = null;
 
 interface OutdatedApp {
   name: string;
@@ -373,6 +374,7 @@ function setupEventListeners(): void {
       app._category = getCategoryForApp(app);
     }
     allApps = apps;
+    loadError = null;
     isLoading = false;
     filterApps();
     setTimeout(() => {
@@ -448,11 +450,25 @@ function setupEventListeners(): void {
       app._category = getCategoryForApp(app);
     }
     allApps = apps;
+    loadError = null;
     isLoading = false;
     filterApps();
     if (loadingMessage) {
       loadingMessage.textContent = 'Apps updated';
     }
+  });
+
+  ipcRenderer.on('all-apps-error', (_event: any, errorMessage: string) => {
+    console.error('[Renderer] Error loading apps:', errorMessage);
+    loadError = errorMessage;
+    if (loadingMessage) {
+      loadingMessage.textContent = `Error: ${errorMessage}`;
+    }
+    filterApps();
+  });
+
+  ipcRenderer.on('installed-apps-error', (_event: any, errorMessage: string) => {
+    console.error('[Renderer] Error getting installed apps:', errorMessage);
   });
   ipcRenderer.on(
     'terminal-prompt-info',
@@ -707,6 +723,13 @@ function loadData(): void {
     return;
   }
 
+  // Show loading state
+  isLoading = true;
+  loadError = null;
+  if (appCount) {
+    appCount.textContent = '...';
+  }
+
   try {
     console.log('[Renderer] Sending get-all-apps');
     ipcRenderer.send('get-all-apps');
@@ -727,6 +750,11 @@ function loadData(): void {
       loadingMessage.textContent = `Error: Cannot connect to main process - ${error.message}`;
     }
   }
+}
+
+function retryLoad(): void {
+  console.log('[Renderer] Retrying load...');
+  loadData();
 }
 
 function renderCategories(): void {
@@ -1019,9 +1047,27 @@ function renderApps(): void {
   }
 
   if (filteredApps.length === 0 && allApps.length === 0 && !isLoading) {
-    appsGrid.innerHTML =
-      '<div class="empty-state">No apps available. Please check your connection.</div>';
+    const errorHtml = loadError
+      ? `<div class="empty-state">
+          <div class="empty-state-icon">⚠️</div>
+          <p>Failed to load apps.</p>
+          <p class="empty-state-detail">${escapeHtml(loadError)}</p>
+          <button class="retry-button" id="retryLoadBtn">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path d="M21.5 2v6h-6M21.34 15.57a10 10 0 1 1-.57-8.38l5.67-5.67"></path>
+            </svg>
+            Retry
+          </button>
+        </div>`
+      : '<div class="empty-state">No apps available. Please check your connection.</div>';
+    appsGrid.innerHTML = errorHtml;
     appsGrid.scrollTop = 0;
+
+    // Attach retry handler
+    const retryBtn = document.getElementById('retryLoadBtn');
+    if (retryBtn) {
+      retryBtn.addEventListener('click', retryLoad);
+    }
     return;
   }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -685,11 +685,50 @@ body {
 
 .empty-state {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   height: 100%;
   color: rgba(193, 182, 255, 0.7);
   font-size: 18px;
+  gap: 12px;
+  text-align: center;
+  padding: 40px;
+}
+
+.empty-state-icon {
+  font-size: 32px;
+  margin-bottom: 8px;
+}
+
+.empty-state-detail {
+  font-size: 13px;
+  color: rgba(255, 91, 128, 0.7);
+  max-width: 400px;
+  word-break: break-word;
+}
+
+.retry-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(99, 255, 210, 0.15);
+  border: 1px solid rgba(99, 255, 210, 0.3);
+  color: #63ffd2;
+  padding: 10px 24px;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: inherit;
+  margin-top: 8px;
+}
+
+.retry-button:hover {
+  background: rgba(99, 255, 210, 0.25);
+  border-color: #63ffd2;
+  box-shadow: 0 0 16px rgba(99, 255, 210, 0.2);
 }
 
 .loading {

--- a/src/utils/brew.ts
+++ b/src/utils/brew.ts
@@ -108,6 +108,7 @@ export async function getInstalledApps(): Promise<InstalledApp[]> {
       })),
     ];
   } catch (error) {
+    console.error('[Brew] Error getting installed apps:', error);
     return [];
   }
 }


### PR DESCRIPTION
## Summary

Fixes the app showing 0 apps on first initialization when the Homebrew API fetch fails. The root cause was missing IPC channels in the preload whitelist — error messages from the main process were silently dropped, leaving the user with an empty state and no way to recover.

Closes #153

## Changes

### src/preload/preload.ts
Added 6 missing IPC channels to `validReceiveChannels`: `all-apps-error`, `installed-apps-error`, `app-details`, `trending-apps-result`, `vulnerabilities-result`, `asset-path`. These were blocking error propagation and feature data from reaching the renderer.

### src/renderer/renderer.ts
- Added `all-apps-error` listener — captures API failure messages and shows them in the UI
- Added `installed-apps-error` listener — logs errors for debugging
- Added `retryLoad()` function — re-sends IPC load requests on button click
- Updated empty state to show error details + retry button when load fails
- Updated `appCount` to show "..." during loading instead of misleading "0"
- Reset `loadError` on successful load

### src/renderer/styles.css
- Styled retry button with app's teal accent color scheme
- Added `.empty-state-icon` and `.empty-state-detail` classes for error display
- Made `.empty-state` a flex column for better error layout

### src/utils/brew.ts
- Added `console.error` logging in `getInstalledApps()` catch block for debugging

## Testing Plan

- [ ] **Manual: Fresh first launch** — simulate by clearing cache (`rm -rf ~/.brewmate`) and launching app; verify apps load from API
- [ ] **Manual: API failure** — disconnect network, launch app; verify error message + retry button appear
- [ ] **Manual: Retry** — click retry button after API failure; verify apps load on retry
- [ ] **Manual: Normal flow** — launch with working network; verify apps load normally, footer count is correct
- [ ] **CI: TypeScript check** — `npx tsc --noEmit` passes with zero errors
- [ ] **CI: Tests** — `npx jest` passes all 40 tests
- [ ] **Edge case: Empty installed list** — user with no Homebrew packages; verify Explore tab still shows available apps

## Summary by Sourcery

Improve initial app loading resilience and error handling when Homebrew API calls fail, providing clearer feedback and a retry path instead of an empty state.

Bug Fixes:
- Ensure IPC error and data channels for apps and related features are whitelisted in the preload script so renderer can receive failures and results.
- Prevent the UI from incorrectly showing zero apps on first launch by tracking load errors and rendering an explicit failure state with retry.

Enhancements:
- Add renderer-side listeners for app loading errors, including logging and reset of error state on successful load.
- Show a loading placeholder for the app count while data is being fetched to avoid misleading values.
- Improve the empty state UI with detailed error messaging, an icon, and a styled retry button consistent with the app theme.
- Log failures in retrieving installed apps in the Homebrew utility to aid debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling with clear messaging when app data fails to load
  * Added a retry button allowing users to recover from failed app loads
  * Enhanced empty state UI styling and error-specific messaging

* **Chores**
  * Updated development configuration to ignore additional files
  * Enhanced error logging for better diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->