### PR TITLE
fix: truncate long version strings in UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brewmate",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brewmate",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "hasInstallScript": true,
       "devDependencies": {
         "@electron/fuses": "^2.1.0",

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1163,7 +1163,7 @@ function renderAppCard(app: App, isInstalled: boolean): string {
               <line x1="3" y1="15" x2="21" y2="15"></line>
             </svg>
           </div>
-          <span class="app-version">v${app.version || 'N/A'}</span>
+          <span class="app-version">v${truncateVersion(app.version) || 'N/A'}</span>
         </div>
         <h3 class="app-title">${escapeHtml(app.name)}</h3>
         <p class="app-description">${escapeHtml(
@@ -1198,7 +1198,7 @@ function openAppDetail(app: App): void {
   const isInstalled = installedApps.has(app.name);
 
   sidebarTitle.textContent = app.name;
-  sidebarVersion.textContent = `v${app.version || 'N/A'}`;
+  sidebarVersion.textContent = `v${truncateVersion(app.version) || 'N/A'}`;
   sidebarType.textContent = app.type;
   sidebarDescription.textContent = app.description || 'No description available.';
 
@@ -1314,6 +1314,15 @@ function escapeHtml(text: string): string {
   return String(text).replace(/[&<>"']/g, (match) => htmlEscapes[match]);
 }
 
+function truncateVersion(version: string, maxLength: number = 15): string {
+  if (!version || version.length <= maxLength) {
+    return version;
+  }
+  // Keep the beginning and end, truncate the middle
+  const halfLength = Math.floor(maxLength / 2);
+  return version.substring(0, halfLength) + '...' + version.substring(version.length - halfLength);
+}
+
 function updateDashboardView(): void {
   // 1. Summary Card - Installed apps breakdown
   const installedCount = installedApps.size;
@@ -1399,10 +1408,10 @@ function renderUpdatesView(): void {
               <span class="updates-app-type">${app.type}</span>
             </td>
             <td>
-              <span class="updates-version-badge">${escapeHtml(app.installedVersion)}</span>
+              <span class="updates-version-badge">${escapeHtml(truncateVersion(app.installedVersion))}</span>
             </td>
             <td>
-              <span class="updates-version-badge latest">${escapeHtml(app.latestVersion)}</span>
+              <span class="updates-version-badge latest">${escapeHtml(truncateVersion(app.latestVersion))}</span>
             </td>
             <td style="text-align: right;">
               <button class="dashboard-action-btn primary action-upgrade-btn" 

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1314,13 +1314,22 @@ function escapeHtml(text: string): string {
   return String(text).replace(/[&<>"']/g, (match) => htmlEscapes[match]);
 }
 
+// Version truncation utility (copy of shared util in src/utils/format.ts)
 function truncateVersion(version: string, maxLength: number = 15): string {
   if (!version || version.length <= maxLength) {
     return version;
   }
-  // Keep the beginning and end, truncate the middle
-  const halfLength = Math.floor(maxLength / 2);
-  return version.substring(0, halfLength) + '...' + version.substring(version.length - halfLength);
+  if (maxLength <= 3) {
+    return version.substring(0, maxLength);
+  }
+  const available = maxLength - 3;
+  const leftLen = Math.ceil(available / 2);
+  const rightLen = Math.floor(available / 2);
+  return (
+    version.substring(0, leftLen) +
+    '...' +
+    version.substring(version.length - rightLen)
+  );
 }
 
 function updateDashboardView(): void {

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1163,7 +1163,7 @@ function renderAppCard(app: App, isInstalled: boolean): string {
               <line x1="3" y1="15" x2="21" y2="15"></line>
             </svg>
           </div>
-          <span class="app-version">v${truncateVersion(app.version) || 'N/A'}</span>
+          <span class="app-version">v${escapeHtml(truncateVersion(app.version)) || 'N/A'}</span>
         </div>
         <h3 class="app-title">${escapeHtml(app.name)}</h3>
         <p class="app-description">${escapeHtml(
@@ -1315,8 +1315,14 @@ function escapeHtml(text: string): string {
 }
 
 // Version truncation utility (copy of shared util in src/utils/format.ts)
-function truncateVersion(version: string, maxLength: number = 15): string {
-  if (!version || version.length <= maxLength) {
+function truncateVersion(
+  version: string | null | undefined,
+  maxLength: number = 15
+): string {
+  if (!version) {
+    return '';
+  }
+  if (version.length <= maxLength) {
     return version;
   }
   if (maxLength <= 3) {

--- a/src/utils/__tests__/truncate.test.ts
+++ b/src/utils/__tests__/truncate.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Standalone test for version truncation logic used in renderer.ts
+ */
+
+function truncateVersion(version: string, maxLength: number = 15): string {
+  if (!version || version.length <= maxLength) {
+    return version;
+  }
+  // Keep the beginning and end, truncate the middle
+  const halfLength = Math.floor(maxLength / 2);
+  return version.substring(0, halfLength) + '...' + version.substring(version.length - halfLength);
+}
+
+describe('truncateVersion', () => {
+  it('should not truncate short versions', () => {
+    expect(truncateVersion('1.0.0')).toBe('1.0.0');
+    expect(truncateVersion('1.2.3-beta')).toBe('1.2.3-beta');
+  });
+
+  it('should truncate long versions', () => {
+    const longVersion = '1.2.3-alpha.20240524.abcdef1234567890';
+    const truncated = truncateVersion(longVersion, 15);
+    expect(truncated.length).toBeLessThanOrEqual(18); // 15 chars + '...' which is 3 chars = 18? 
+    // Wait, the logic is: halfLength (7) + '...' (3) + halfLength (7) = 17 chars.
+    expect(truncated).toBe('1.2.3-a...4567890');
+    expect(truncated.length).toBe(17);
+  });
+
+  it('should handle boundary lengths', () => {
+    expect(truncateVersion('123456789012345', 15)).toBe('123456789012345');
+    expect(truncateVersion('1234567890123456', 15)).toBe('1234567...0123456');
+  });
+
+  it('should handle empty or null input', () => {
+    expect(truncateVersion('')).toBe('');
+    expect(truncateVersion(null as any)).toBe(null);
+  });
+});

--- a/src/utils/__tests__/truncate.test.ts
+++ b/src/utils/__tests__/truncate.test.ts
@@ -1,15 +1,7 @@
 /**
- * Standalone test for version truncation logic used in renderer.ts
+ * Test for version truncation logic
  */
-
-function truncateVersion(version: string, maxLength: number = 15): string {
-  if (!version || version.length <= maxLength) {
-    return version;
-  }
-  // Keep the beginning and end, truncate the middle
-  const halfLength = Math.floor(maxLength / 2);
-  return version.substring(0, halfLength) + '...' + version.substring(version.length - halfLength);
-}
+import { truncateVersion } from '../format';
 
 describe('truncateVersion', () => {
   it('should not truncate short versions', () => {
@@ -17,18 +9,22 @@ describe('truncateVersion', () => {
     expect(truncateVersion('1.2.3-beta')).toBe('1.2.3-beta');
   });
 
-  it('should truncate long versions', () => {
+  it('should truncate long versions to exactly maxLength', () => {
     const longVersion = '1.2.3-alpha.20240524.abcdef1234567890';
     const truncated = truncateVersion(longVersion, 15);
-    expect(truncated.length).toBeLessThanOrEqual(18); // 15 chars + '...' which is 3 chars = 18? 
-    // Wait, the logic is: halfLength (7) + '...' (3) + halfLength (7) = 17 chars.
-    expect(truncated).toBe('1.2.3-a...4567890');
-    expect(truncated.length).toBe(17);
+    expect(truncated).toBe('1.2.3-...567890');
+    expect(truncated.length).toBe(15);
   });
 
   it('should handle boundary lengths', () => {
     expect(truncateVersion('123456789012345', 15)).toBe('123456789012345');
-    expect(truncateVersion('1234567890123456', 15)).toBe('1234567...0123456');
+    expect(truncateVersion('1234567890123456', 15)).toBe('123456...123456');
+    expect(truncateVersion('1234567890123456', 15).length).toBe(15);
+  });
+
+  it('should handle small maxLength', () => {
+    expect(truncateVersion('1.2.3', 3)).toBe('1.2');
+    expect(truncateVersion('1.2.3', 2)).toBe('1.');
   });
 
   it('should handle empty or null input', () => {

--- a/src/utils/__tests__/truncate.test.ts
+++ b/src/utils/__tests__/truncate.test.ts
@@ -29,6 +29,7 @@ describe('truncateVersion', () => {
 
   it('should handle empty or null input', () => {
     expect(truncateVersion('')).toBe('');
-    expect(truncateVersion(null as any)).toBe(null);
+    expect(truncateVersion(null as any)).toBe('');
+    expect(truncateVersion(undefined as any)).toBe('');
   });
 });

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,28 @@
+/**
+ * Utility functions for formatting strings and data
+ */
+
+/**
+ * Truncates a version string to a maximum length, preserving the start and end.
+ * Example: "1.2.3-alpha.20240524.abcdef1234567890" -> "1.2.3-...567890"
+ *
+ * @param version The version string to truncate
+ * @param maxLength The maximum allowed length (default: 15)
+ * @returns The truncated version string
+ */
+export function truncateVersion(version: string, maxLength: number = 15): string {
+  if (!version || version.length <= maxLength) {
+    return version;
+  }
+  if (maxLength <= 3) {
+    return version.substring(0, maxLength);
+  }
+  const available = maxLength - 3;
+  const leftLen = Math.ceil(available / 2);
+  const rightLen = Math.floor(available / 2);
+  return (
+    version.substring(0, leftLen) +
+    '...' +
+    version.substring(version.length - rightLen)
+  );
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -10,8 +10,14 @@
  * @param maxLength The maximum allowed length (default: 15)
  * @returns The truncated version string
  */
-export function truncateVersion(version: string, maxLength: number = 15): string {
-  if (!version || version.length <= maxLength) {
+export function truncateVersion(
+  version: string | null | undefined,
+  maxLength: number = 15
+): string {
+  if (!version) {
+    return '';
+  }
+  if (version.length <= maxLength) {
     return version;
   }
   if (maxLength <= 3) {


### PR DESCRIPTION
## Summary by Sourcery

Truncate long application version strings in the UI to prevent layout issues while preserving key parts of the version.

Bug Fixes:
- Prevent excessively long version strings from overflowing or disrupting layouts in app cards, sidebar details, and the updates view.

Tests:
- Add unit tests covering the version truncation behavior, including non-truncation of short versions, truncation of long versions, boundary lengths, and empty or null input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Long version strings are now truncated across the application, improving readability on app cards, in the details sidebar, and in the updates table.

* **Tests**
  * Added comprehensive tests verifying version truncation behavior, including edge cases and empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->