### PR TITLE
fix: bundle node_modules in application ASAR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ yarn-error.log*
 docs/
 .dev/
 AGENTS.md
+memory-bank/

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -12,7 +12,6 @@ files:
   - 'dist/**/*'
   - 'locales/**/*'
   - 'package.json'
-  - '!**/node_modules/**/*'
   - '!**/src/**/*'
   - '!**/*.{iml,o,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,xproj}'
   - '!.editorconfig'


### PR DESCRIPTION
## Description

Removes the `!**/node_modules/***` exclusion from `electron-builder.yml`. 

### Why is this needed?
By default, `electron-builder` auto-bundles production `dependencies` (like `i18next`) into the ASAR file. Explicitly excluding `node_modules` prevents this, causing an uncaught `Cannot find module 'i18next'` exception when running the packaged release app.

### Changes
- Removed the line `- '!**/node_modules/**/*'` from `electron-builder.yml`.

## Summary by Sourcery

Build:
- Update electron-builder configuration to no longer exclude node_modules from the packaged application files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to refine file inclusion rules for the application package.
  * Added version control exclusion for memory management directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->