### PR TITLE
ci: add startup smoke test verification to PR workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,14 +39,12 @@ jobs:
           TEST_STARTUP: 'true'
           ELECTRON_ENABLE_LOGGING: '1'
         run: |
-          APP_PATH=$(find dist-app -name "BrewMate.app" | head -n 1)
-          if [ -z "$APP_PATH" ]; then
-            echo "Error: BrewMate.app not found!"
+          ASAR_PATH=$(find dist-app -name "app.asar" | head -n 1)
+          if [ -z "$ASAR_PATH" ]; then
+            echo "Error: app.asar not found!"
             exit 1
           fi
-          echo "Found application at: $APP_PATH"
-          echo "Ad-hoc signing the application bundle..."
-          codesign --force --deep --sign - "$APP_PATH"
-          echo "Launching application..."
-          "$APP_PATH/Contents/MacOS/BrewMate" --test-startup --no-sandbox
+          echo "Found ASAR at: $ASAR_PATH"
+          echo "Launching application from ASAR..."
+          npx electron "$ASAR_PATH" --test-startup --no-sandbox
         working-directory: .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,5 +43,8 @@ jobs:
             exit 1
           fi
           echo "Found application at: $APP_PATH"
+          echo "Ad-hoc signing the application bundle..."
+          codesign --force --deep --sign - "$APP_PATH"
+          echo "Launching application..."
           "$APP_PATH/Contents/MacOS/BrewMate" --test-startup
         working-directory: .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,6 +34,8 @@ jobs:
         working-directory: .
 
       - name: Verify Startup (Smoke Test)
+        env:
+          TEST_STARTUP: 'true'
         run: |
           APP_PATH=$(find dist-app -name "BrewMate.app" | head -n 1)
           if [ -z "$APP_PATH" ]; then

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,8 +34,10 @@ jobs:
         working-directory: .
 
       - name: Verify Startup (Smoke Test)
+        timeout-minutes: 2
         env:
           TEST_STARTUP: 'true'
+          ELECTRON_ENABLE_LOGGING: '1'
         run: |
           APP_PATH=$(find dist-app -name "BrewMate.app" | head -n 1)
           if [ -z "$APP_PATH" ]; then
@@ -46,5 +48,5 @@ jobs:
           echo "Ad-hoc signing the application bundle..."
           codesign --force --deep --sign - "$APP_PATH"
           echo "Launching application..."
-          "$APP_PATH/Contents/MacOS/BrewMate" --test-startup
+          "$APP_PATH/Contents/MacOS/BrewMate" --test-startup --no-sandbox
         working-directory: .

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,6 +24,22 @@ jobs:
       - name: Build Electron App
         run: |
           npm run build
-          pwd
-          ls -la
+        working-directory: .
+
+      - name: Package App (Dry Run)
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+        run: |
+          npx electron-builder --mac --dir
+        working-directory: .
+
+      - name: Verify Startup (Smoke Test)
+        run: |
+          APP_PATH=$(find dist-app -name "BrewMate.app" | head -n 1)
+          if [ -z "$APP_PATH" ]; then
+            echo "Error: BrewMate.app not found!"
+            exit 1
+          fi
+          echo "Found application at: $APP_PATH"
+          "$APP_PATH/Contents/MacOS/BrewMate" --test-startup
         working-directory: .

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -11,6 +11,7 @@ asar: true
 files:
   - 'dist/**/*'
   - 'locales/**/*'
+  - 'node_modules/**/*'
   - 'package.json'
   - '!**/src/**/*'
   - '!**/*.{iml,o,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,xproj}'

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -68,13 +68,14 @@ function initializeApp(): void {
   initI18n();
   console.log('[Main] i18n initialized');
 
+  if (process.argv.includes('--test-startup') || process.env.TEST_STARTUP === 'true') {
+    console.log('[Main] Startup smoke test passed successfully.');
+    app.exit(0);
+    return;
+  }
+
   // Create window when ready
   app.whenReady().then(() => {
-    if (process.argv.includes('--test-startup') || process.env.TEST_STARTUP === 'true') {
-      console.log('[Main] Startup smoke test passed successfully.');
-      app.exit(0);
-      return;
-    }
     console.log('[Main] App ready, creating window...');
     createWindow();
   });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -68,14 +68,14 @@ function initializeApp(): void {
   initI18n();
   console.log('[Main] i18n initialized');
 
-  if (process.argv.includes('--test-startup') || process.env.TEST_STARTUP === 'true') {
-    console.log('[Main] Startup smoke test passed successfully.');
-    app.exit(0);
-    return;
-  }
-
   // Create window when ready
   app.whenReady().then(() => {
+    if (process.argv.includes('--test-startup') || process.env.TEST_STARTUP === 'true') {
+      console.log('[Main] Startup smoke test passed successfully.');
+      app.exit(0);
+      return;
+    }
+
     console.log('[Main] App ready, creating window...');
     createWindow();
   });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4,6 +4,10 @@ import { setupIpcHandlers } from './ipcHandlers';
 import { logCommand } from '../utils/logger';
 import { initI18n, changeLanguage, t, getCurrentLanguage } from './i18n';
 
+if (process.argv.includes('--test-startup') || process.env.TEST_STARTUP === 'true') {
+  app.disableHardwareAcceleration();
+}
+
 let mainWindow: BrowserWindow | null = null;
 
 function createWindow(): void {
@@ -64,14 +68,13 @@ function initializeApp(): void {
   initI18n();
   console.log('[Main] i18n initialized');
 
-  if (process.argv.includes('--test-startup') || process.env.TEST_STARTUP === 'true') {
-    console.log('[Main] Startup smoke test passed successfully.');
-    app.exit(0);
-    return;
-  }
-
   // Create window when ready
   app.whenReady().then(() => {
+    if (process.argv.includes('--test-startup') || process.env.TEST_STARTUP === 'true') {
+      console.log('[Main] Startup smoke test passed successfully.');
+      app.exit(0);
+      return;
+    }
     console.log('[Main] App ready, creating window...');
     createWindow();
   });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -68,14 +68,15 @@ function initializeApp(): void {
   initI18n();
   console.log('[Main] i18n initialized');
 
+  if (process.argv.includes('--test-startup') || process.env.TEST_STARTUP === 'true') {
+    console.log('[Main] Startup smoke test passed successfully. Exiting before UI init.');
+    app.exit(0);
+    process.exit(0); // Add process.exit to be absolutely sure
+    return;
+  }
+
   // Create window when ready
   app.whenReady().then(() => {
-    if (process.argv.includes('--test-startup') || process.env.TEST_STARTUP === 'true') {
-      console.log('[Main] Startup smoke test passed successfully.');
-      app.exit(0);
-      return;
-    }
-
     console.log('[Main] App ready, creating window...');
     createWindow();
   });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -64,6 +64,12 @@ function initializeApp(): void {
   initI18n();
   console.log('[Main] i18n initialized');
 
+  if (process.argv.includes('--test-startup')) {
+    console.log('[Main] Startup smoke test passed successfully.');
+    app.exit(0);
+    return;
+  }
+
   // Create window when ready
   app.whenReady().then(() => {
     console.log('[Main] App ready, creating window...');

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -64,7 +64,7 @@ function initializeApp(): void {
   initI18n();
   console.log('[Main] i18n initialized');
 
-  if (process.argv.includes('--test-startup')) {
+  if (process.argv.includes('--test-startup') || process.env.TEST_STARTUP === 'true') {
     console.log('[Main] Startup smoke test passed successfully.');
     app.exit(0);
     return;


### PR DESCRIPTION
Draft PR to verify the automated startup smoke test PoC on CI. Checks if the built application binary launches successfully and processes the --test-startup flag.

## Summary by Sourcery

Add a CI smoke test to verify the packaged Electron app can start in a headless test mode and exit cleanly.

New Features:
- Introduce a startup smoke test mode in the Electron main process that can be triggered via a CLI flag or environment variable to exit early after successful initialization.

Enhancements:
- Update Electron build configuration to include node_modules in the asar bundle to support the new startup verification flow in CI.

CI:
- Extend the PR build-and-test workflow to package the Electron app in a dry-run mode and run an automated startup smoke test against the built ASAR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated startup verification to CI/CD pipeline to validate application launches successfully on macOS

* **Chores**
  * Enhanced build process with packaging validation step
  * Optimized application package size by excluding build dependencies from distribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->