### PR TITLE
security(renderer): prefer textContent over innerHTML for dependencies

### DIFF
--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -767,9 +767,9 @@ function setupIpcListeners(): void {
 
       const deps = details.dependencies || [];
       if (deps.length > 0) {
-        sidebarDependencies.innerHTML = deps.join(', ');
+        sidebarDependencies.textContent = deps.join(', ');
       } else {
-        sidebarDependencies.innerHTML = 'None';
+        sidebarDependencies.textContent = 'None';
       }
 
       if (details.githubStats && details.githubStats.stars !== undefined) {
@@ -780,7 +780,7 @@ function setupIpcListeners(): void {
       }
     } else {
       sidebarSize.textContent = 'Failed to load';
-      sidebarDependencies.innerHTML = '-';
+      sidebarDependencies.textContent = '-';
       sidebarGithubStatsRow.style.display = 'none';
     }
   });
@@ -1448,7 +1448,7 @@ function openAppDetail(app: App): void {
   sidebarExtendedDetails.style.display = 'block';
   sidebarDetailsLoader.style.display = 'none';
   sidebarSize.textContent = uiTranslations.loading;
-  sidebarDependencies.innerHTML = uiTranslations.loading;
+  sidebarDependencies.textContent = uiTranslations.loading;
   sidebarGithubStatsRow.style.display = 'none';
   sidebarVulnRow.style.display = 'none';
 


### PR DESCRIPTION
Addresses feedback from Sourcery and CodeRabbit on PR #343: replaces `.innerHTML` with `.textContent` for the `sidebarDependencies` element to eliminate unnecessary HTML parsing and potential XSS vulnerabilities.

## Summary by Sourcery

Enhancements:
- Use textContent instead of innerHTML when rendering sidebar dependencies and loading states to reduce XSS risk and HTML parsing overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dependency list display in the app sidebar to ensure proper rendering when loading app details and switching between applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->