### PR TITLE
fix: eliminate runtime file I/O for categories - use compile-time JSON import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brewmate",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brewmate",
-      "version": "1.0.32",
+      "version": "1.0.33",
       "hasInstallScript": true,
       "dependencies": {
         "i18next": "^26.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brewmate",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "description": "BrewMate - A modern package manager GUI for macOS",
   "author": "Roman Kurnovskii",
   "main": "dist/index.js",

--- a/src/main/ipcHandlers.ts
+++ b/src/main/ipcHandlers.ts
@@ -10,6 +10,7 @@ import { getEnvWithBrewPath } from '../utils/path';
 import { HOMEBREW_CASKS_JSON_URL, HOMEBREW_FORMULAS_JSON_URL } from '../constants';
 import { App, LoadingStatus } from '../types';
 import { t, changeLanguage, getCurrentLanguage } from './i18n';
+import categoriesData from '../assets/categories.json';
 
 export function setupIpcHandlers(): void {
   // i18n handlers
@@ -512,48 +513,8 @@ export function setupIpcHandlers(): void {
   });
 
   // Get categories configuration
-  ipcMain.handle('get-categories', async () => {
-    const fs = require('fs').promises;
-
-    // Collect context for diagnostics
-    const context = {
-      isPackaged: app.isPackaged,
-      resourcesPath: process.resourcesPath,
-      dirname: __dirname,
-      cwd: process.cwd(),
-    };
-
-    // Build list of paths to try — primary first, then fallbacks
-    const pathsToTry: string[] = [];
-    if (app.isPackaged) {
-      // Production: extraResources puts assets at Resources/assets/
-      pathsToTry.push(path.join(process.resourcesPath, 'assets', 'categories.json'));
-      // Fallback: dev-style path in case the build structure differs
-      pathsToTry.push(path.join(__dirname, '../assets', 'categories.json'));
-      // Fallback: project root assets/ (for some self-compiled scenarios)
-      pathsToTry.push(path.join(process.cwd(), 'assets', 'categories.json'));
-    } else {
-      // Development: compiled output at dist/, assets at dist/assets/
-      pathsToTry.push(path.join(__dirname, '../assets', 'categories.json'));
-      // Fallback: source directory directly
-      pathsToTry.push(path.join(__dirname, '../../src/assets', 'categories.json'));
-    }
-
-    let lastError: Error | null = null;
-    for (const assetPath of pathsToTry) {
-      try {
-        const data = await fs.readFile(assetPath, 'utf8');
-        return JSON.parse(data);
-      } catch (error) {
-        lastError = error as Error;
-        console.error(`[IPC] Failed to read categories from: ${assetPath}`, error);
-      }
-    }
-
-    // All paths failed — log full context and throw
-    console.error('[IPC] All category paths failed:', JSON.stringify(context, null, 2));
-    console.error('[IPC] Last error:', lastError);
-    throw lastError || new Error('Unable to load categories from any path');
-  });
+  // Categories data is imported at compile time via resolveJsonModule,
+  // eliminating runtime file I/O and path resolution issues in packaged apps.
+  ipcMain.handle('get-categories', async () => categoriesData);
 }
 


### PR DESCRIPTION
## Problem

Issue #354 — categories fail to load in packaged app on macOS 27 beta. The error path was `/assets/categories.json` (root), showing `process.resourcesPath` returns `/` on this macOS version with Electron 42.x.

Previous fix (v1.0.32) added fallback paths, but all failed because:
- `process.resourcesPath` returns `/` (filesystem root)
- `fs.readFile` can't read from inside Electron ASAR archives
- `process.cwd()` is also `/` when launched from Finder

## Solution (Musk Algorithm)

**Delete** the entire runtime file I/O approach. Instead, import the 499KB `categories.json` at **compile time** via TypeScript's `resolveJsonModule`. The compiled `require()` call works inside Electron's ASAR because Electron specifically patches `require` for ASAR support — eliminating all path resolution, all fallback logic, and all file system dependencies.

### Changes

`src/main/ipcHandlers.ts`: +4 / -43 lines
- Added: `import categoriesData from '../assets/categories.json';`
- Replaced: 40+ lines of try-catch + fallback path logic → single line: `ipcMain.handle('get-categories', async () => categoriesData);`

### Verification
- ✅ TypeScript: clean compile (exit 0)
- ✅ Build: succeeds
- ✅ All 66 tests pass
- ✅ Version bumped to 1.0.33

## Summary by Sourcery

Load categories configuration via a compile-time JSON import instead of runtime file I/O to ensure reliable access in packaged Electron apps.

Bug Fixes:
- Resolve categories loading failures in packaged macOS builds by removing filesystem path resolution and ASAR-incompatible file reads.

Enhancements:
- Simplify the IPC handler for category retrieval to return pre-imported JSON data without fallback logic or diagnostics.

Build:
- Bump application version from 1.0.32 to 1.0.33 in package metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated category loading to be more reliable across environments, helping ensure categories appear consistently.
  * Improved app versioning from **1.0.32** to **1.0.33**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->