### PR TITLE
⚡ Bolt: [performance improvement] Single-pass array filtering in SoftwareManager

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -40,3 +40,6 @@
 ## 2024-07-11 - Chain Methods vs Single Pass Loops
 **Learning:** In V8/JavaScript, chaining multiple array methods (`Object.entries(obj).sort().filter().slice()`) creates several intermediate arrays that trigger Garbage Collection and delay execution. When this runs frequently on the UI thread (like chart rendering), it causes stuttering.
 **Action:** When extracting data from objects (especially with conditionals and limits), always replace chained array methods with a single-pass `for` loop over `Object.keys()` to populate an array, and then apply `sort()` and `length` truncation directly.
+## 2026-07-13 - [Optimizing Query Method with Single Pass Loop]
+**Learning:** When applying multiple sequential filters to a dataset (e.g., chained `.filter()` calls in `SoftwareManager.query()`), it creates several intermediate array allocations causing high memory overhead.
+**Action:** Consolidating multiple chained `.filter()` calls into a single native `for` loop significantly outperforms the chain by eliminating multiple intermediate array allocations and redundant iterations.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -42,4 +42,4 @@
 **Action:** When extracting data from objects (especially with conditionals and limits), always replace chained array methods with a single-pass `for` loop over `Object.keys()` to populate an array, and then apply `sort()` and `length` truncation directly.
 ## 2026-07-13 - [Optimizing Query Method with Single Pass Loop]
 **Learning:** When applying multiple sequential filters to a dataset (e.g., chained `.filter()` calls in `SoftwareManager.query()`), it creates several intermediate array allocations causing high memory overhead.
-**Action:** Consolidating multiple chained `.filter()` calls into a single native `for` loop significantly outperforms the chain by eliminating multiple intermediate array allocations and redundant iterations.
+**Action:** Consolidate multiple chained `.filter()` calls into a single `for...of` loop over the source iterable. Iterating a Map's `.values()` iterator directly avoids the intermediate array that `Array.from()` or `[...map.values()]` would allocate, eliminating both filter-chain intermediates and the materialization allocation.

--- a/src/managers/SoftwareManager.ts
+++ b/src/managers/SoftwareManager.ts
@@ -37,8 +37,6 @@ export class SoftwareManager {
   }
 
   async query(filters: SoftwareQuery = {}): Promise<Software[]> {
-    let results = Array.from(this.softwareMap.values());
-
     const {
       keyword,
       category,
@@ -51,35 +49,45 @@ export class SoftwareManager {
       offset,
     } = filters;
 
-    // Keyword filter (matches name, description, tags)
-    if (keyword) {
-      const kw = keyword.toLowerCase();
-      results = results.filter(
-        (s) =>
-          s.name.toLowerCase().includes(kw) ||
-          s.description.toLowerCase().includes(kw) ||
-          s.tags.some((t) => t.toLowerCase().includes(kw))
-      );
-    }
+    const results: Software[] = [];
+    const values = Array.from(this.softwareMap.values());
+    const kw = keyword ? keyword.toLowerCase() : '';
 
-    // Category filter
-    if (category) {
-      results = results.filter((s) => s.category === category);
-    }
+    // Optimization: Single-pass for loop over values, replacing multiple chained .filter() allocations
+    for (let i = 0; i < values.length; i++) {
+      const s = values[i];
 
-    // Tag filter
-    if (tag) {
-      results = results.filter((s) => s.tags.includes(tag));
-    }
+      // Keyword filter (matches name, description, tags)
+      if (kw) {
+        let match = false;
+        if (s.name.toLowerCase().indexOf(kw) !== -1) {
+          match = true;
+        } else if (s.description.toLowerCase().indexOf(kw) !== -1) {
+          match = true;
+        } else {
+          for (let j = 0; j < s.tags.length; j++) {
+            if (s.tags[j].toLowerCase().indexOf(kw) !== -1) {
+              match = true;
+              break;
+            }
+          }
+        }
+        if (!match) continue;
+      }
 
-    // License filter
-    if (license) {
-      results = results.filter((s) => s.license === license);
-    }
+      // Category filter
+      if (category && s.category !== category) continue;
 
-    // Status filter
-    if (status && status !== 'all') {
-      results = results.filter((s) => s.status === status);
+      // Tag filter
+      if (tag && s.tags.indexOf(tag) === -1) continue;
+
+      // License filter
+      if (license && s.license !== license) continue;
+
+      // Status filter
+      if (status && status !== 'all' && s.status !== status) continue;
+
+      results.push(s);
     }
 
     // Sorting

--- a/src/managers/SoftwareManager.ts
+++ b/src/managers/SoftwareManager.ts
@@ -115,14 +115,15 @@ export class SoftwareManager {
     }
 
     // Pagination
+    let paginatedResults = results;
     if (offset !== undefined) {
-      results = results.slice(offset);
+      paginatedResults = paginatedResults.slice(offset);
     }
     if (limit !== undefined) {
-      results = results.slice(0, limit);
+      paginatedResults = paginatedResults.slice(0, limit);
     }
 
-    return results;
+    return paginatedResults;
   }
 
   async add(software: Omit<Software, 'id' | 'installedAt' | 'updatedAt'>): Promise<Software> {

--- a/src/managers/SoftwareManager.ts
+++ b/src/managers/SoftwareManager.ts
@@ -50,12 +50,11 @@ export class SoftwareManager {
     } = filters;
 
     const results: Software[] = [];
-    const values = Array.from(this.softwareMap.values());
     const kw = keyword ? keyword.toLowerCase() : '';
 
-    // Optimization: Single-pass for loop over values, replacing multiple chained .filter() allocations
-    for (let i = 0; i < values.length; i++) {
-      const s = values[i];
+    // Optimization: Single-pass for-of loop over values, replacing multiple chained .filter() allocations.
+    // Iterates the Map's values iterator directly to avoid an intermediate Array.from() allocation.
+    for (const s of this.softwareMap.values()) {
 
       // Keyword filter (matches name, description, tags)
       if (kw) {


### PR DESCRIPTION
💡 What: Replaced chained `.filter()` calls in `SoftwareManager.query()` with a single native `for` loop. Added fast-path `.indexOf(kw) !== -1` for string matching.
🎯 Why: Chaining array methods like `.filter()` causes intermediate array allocations and triggers garbage collection. Consolidating logic into a single loop eliminates redundant iterations and intermediate arrays.
📊 Impact: Reduces memory allocation and avoids processing the same list multiple times, improving filtering time (especially when the data size grows).
🔬 Measurement: Can verify the logic via `npm test` and `npm run build:renderer`. Memory/CPU profiling during bulk `SoftwareManager.query()` calls will show reduced GC and execution time.

---
*PR created automatically by Jules for task [1840587714972133314](https://jules.google.com/task/1840587714972133314) started by @romankurnovskii*

## Summary by Sourcery

Optimize SoftwareManager.query() filtering to use a single-pass loop for better performance and memory usage.

Enhancements:
- Replace chained array filter operations in SoftwareManager.query() with a single-pass for loop that applies all filters in one iteration.
- Add more efficient keyword, tag, license, category, and status checks during software query evaluation to reduce unnecessary processing.

Documentation:
- Document single-pass loop optimization and filtering best practices in .jules/bolt.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Streamlined software search and filtering by reducing repeated filtering passes and reusing the normalized keyword during matching.
  * Improved query efficiency on large datasets by iterating sources directly to avoid unnecessary intermediate allocations.
* **Bug Fixes**
  * Made pagination handling more reliable by applying offset/limit slicing without mutating the full result set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->