### PR TITLE
feat: Linux support — cross-platform expansion (issue #385)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,3 +48,48 @@ jobs:
           echo "Launching application from ASAR..."
           npx electron "$ASAR_PATH" --test-startup --no-sandbox
         working-directory: .
+
+  build-and-test-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential python3 libgtk-3-0 libnotify4 libnss3 libxss1 libasound2t64 || \
+          sudo apt-get install -y build-essential python3 libgtk-3-0 libnotify4 libnss3 libxss1 libasound2
+
+      - name: Install Dependencies
+        run: npm install
+        working-directory: .
+
+      - name: Tests
+        run: npm test
+        working-directory: .
+
+      - name: Build Electron App
+        run: npm run build
+        working-directory: .
+
+      - name: Package App (Linux Dry Run)
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+        run: npx electron-builder --linux --dir
+        working-directory: .
+
+      - name: Verify Startup (Smoke Test)
+        timeout-minutes: 2
+        env:
+          TEST_STARTUP: 'true'
+          ELECTRON_ENABLE_LOGGING: '1'
+        run: |
+          ASAR_PATH=$(find dist-app -name "app.asar" | head -n 1)
+          if [ -z "$ASAR_PATH" ]; then
+            echo "Error: app.asar not found!"
+            exit 1
+          fi
+          echo "Found ASAR at: $ASAR_PATH"
+          echo "Launching application from ASAR..."
+          npx electron "$ASAR_PATH" --test-startup --no-sandbox
+        working-directory: .

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **BrewMate - Homebrew GUI**
 
-BrewMate is a macOS GUI application that makes it easy to search for, install, and uninstall Homebrew casks. You can also see the top downloaded casks.
+BrewMate is a GUI application for [Homebrew](https://brew.sh/) on **macOS** and **Linux**. Search, install, upgrade, and uninstall formulae and casks (where Homebrew supports them). You can also browse top downloads and manage brew services.
 
 Includes third party apps + from [awesome-brew](https://github.com/romankurnovskii/homebrew-awesome-brew/)
 
@@ -15,6 +15,7 @@ Includes third party apps + from [awesome-brew](https://github.com/romankurnovsk
 - [x] list local installed
 - [x] top installs
 - [x] show logs on install/uninstall
+- [x] Linux support (Homebrew / Linuxbrew; formula-primary)
 - [ ] add 3rd party taps
 - [ ] handle apps required sudo/pass on install/uninstall
 
@@ -22,30 +23,52 @@ Includes third party apps + from [awesome-brew](https://github.com/romankurnovsk
 
 Before you begin, ensure you have met the following requirements:
 
-- **macOS**: This package is designed to work on macOS. Ensure you are using a compatible version.
-- **Homebrew**: This package requires [Homebrew](https://brew.sh/) to be installed on your system. Homebrew is a package manager for macOS that simplifies the installation of software. If you don't have Homebrew installed, you can install it by running the following command in your terminal:
+- **macOS** or **Linux** (Ubuntu 22.04+ / Debian-class recommended for Linux)
+- **Homebrew**: Required on both platforms. Install with:
 
 ```sh
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
+On Linux, use the official prefix `/home/linuxbrew/.linuxbrew` when possible (best bottle support). Follow the installer’s “Next steps” to add `brew` to your `PATH`.
+
+### Linux system packages
+
+For running Electron / building from source on Debian/Ubuntu:
+
+```sh
+sudo apt-get install build-essential procps curl file git \
+  libgtk-3-dev libnotify-dev libnss3 libxss1 libasound2
+```
+
 # Install
 
-### Option 1
-
-In terminal:
+### macOS — Option 1 (Homebrew cask)
 
 ```sh
 brew install romankurnovskii/BrewMate/brewmate --cask
 ```
 
-### Option 2
+### macOS — Option 2 (DMG)
 
 1. Download the latest DMG file from the [releases page](https://github.com/romankurnovskii/BrewMate/releases).
 2. Double-click the DMG file to open it.
 3. Drag the BrewMate app to your Applications folder.
 
-## First time launch
+### Linux (from source / local package)
+
+Linux release artifacts may be produced with electron-builder (AppImage / `.deb`). From a clone:
+
+```sh
+npm install
+npm run build:linux
+```
+
+Artifacts land in `dist-app/`. You can also run in development after `npm run build` with `npm start`.
+
+> **Note:** On Linux, Homebrew is formula-primary. Casks are shown when available, but many macOS-only casks will not install. Interactive upgrades use the in-app terminal (external Terminal.app is macOS-only).
+
+## First time launch (macOS)
 
 1. Navigate to your "Applications" folder.
 1. Find the app `BrewMate` and right-click on it.
@@ -55,7 +78,8 @@ brew install romankurnovskii/BrewMate/brewmate --cask
 
 # Requirements
 
-- macOS 10.15 or later.
+- macOS 10.15 or later, **or**
+- Linux with Homebrew (Ubuntu 22.04+ recommended)
 
 # Development / Build
 
@@ -66,9 +90,7 @@ brew install romankurnovskii/BrewMate/brewmate --cask
 
 ## Build Types
 
-BrewMate supports two build types:
-
-### Local Test Build
+### Local Test Build (macOS)
 
 Build a version you can run and test on your Mac (direct distribution):
 
@@ -77,6 +99,14 @@ npm run build:mac
 ```
 
 This creates a DMG in `dist-app/` that you can install and run locally.
+
+### Local Test Build (Linux)
+
+```bash
+npm run build:linux
+```
+
+This creates AppImage and/or `.deb` packages in `dist-app/` (see `electron-builder.yml`).
 
 ### Mac App Store Build
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brewmate",
   "version": "1.0.34",
-  "description": "BrewMate - A modern package manager GUI for macOS",
+  "description": "BrewMate - A modern Homebrew package manager GUI for macOS and Linux",
   "author": "Roman Kurnovskii",
   "main": "dist/index.js",
   "scripts": {

--- a/src/main/__tests__/ptyManager.test.ts
+++ b/src/main/__tests__/ptyManager.test.ts
@@ -158,4 +158,26 @@ describe('PTY Manager', () => {
     const mockPty = getLastPtyInstance();
     mockPty._triggerExit(0);
   });
+
+  it('open-external-terminal soft-fails with a clear message on non-darwin', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+
+    jest.clearAllMocks();
+    ptyManager.setupPtyIpcHandlers();
+    const handleCalls = (ipcMain.handle as jest.Mock).mock.calls;
+    const openExternalCall = handleCalls.find(
+      (call: unknown[]) => call[0] === 'open-external-terminal'
+    );
+    expect(openExternalCall).toBeDefined();
+    const handler = openExternalCall[1] as (event: unknown, cask: string) => Promise<void>;
+
+    await expect(handler({}, 'some-cask')).rejects.toThrow(
+      /only supported on macOS|in-app terminal/i
+    );
+
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
 });

--- a/src/main/ptyManager.ts
+++ b/src/main/ptyManager.ts
@@ -115,10 +115,14 @@ export function setupPtyIpcHandlers(): void {
     return true;
   });
 
-  // Fallback: open macOS Terminal.app with the same brew command
+  // Fallback: open an external terminal with the same brew command (macOS only).
+  // On Linux/Windows the in-app PTY is the supported interactive path; soft-fail
+  // with a clear error so the renderer can keep using embedded terminal input.
   ipcMain.handle('open-external-terminal', async (_event, caskName: string) => {
     if (process.platform !== 'darwin') {
-      throw new Error('Opening external Terminal is only supported on macOS');
+      throw new Error(
+        'Opening an external terminal is only supported on macOS. Use the in-app terminal to enter your password.'
+      );
     }
 
     const cmd = `brew upgrade --cask ${caskName}`;

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -647,20 +647,30 @@ function setupIpcListeners(): void {
       );
       terminalOutput.scrollTop = terminalOutput.scrollHeight;
     } else if (choice === 'external') {
-      // Kill PTY, launch Terminal.app
+      // Kill PTY, launch external terminal (macOS Terminal.app)
       if (ipcRenderer.killPty) {
         await ipcRenderer.killPty();
       }
-      if (ipcRenderer.openExternalTerminal) {
-        await ipcRenderer.openExternalTerminal(caskName);
+      try {
+        if (ipcRenderer.openExternalTerminal) {
+          await ipcRenderer.openExternalTerminal(caskName);
+        }
+        terminalOutput.insertAdjacentHTML(
+          'beforeend',
+          `<span class="terminal-prompt">🖥️</span> Opened external terminal for ${escapeHtml(caskName)} upgrade.\n`
+        );
+        // Mark as "success" so the UI removes it from the list
+        ipcRenderer.send('upgrade-complete', { appName: caskName, success: true });
+      } catch (err: any) {
+        const message = err?.message || String(err);
+        terminalOutput.insertAdjacentHTML(
+          'beforeend',
+          `<span class="terminal-prompt">⚠️</span> Could not open external terminal: ${escapeHtml(message)}\n` +
+            `<span class="terminal-prompt">💡</span> Use the in-app terminal (embedded option) to enter your password.\n`
+        );
+        ipcRenderer.send('upgrade-complete', { appName: caskName, success: false });
       }
-      terminalOutput.insertAdjacentHTML(
-        'beforeend',
-        `<span class="terminal-prompt">🖥️</span> Opened Terminal.app for ${escapeHtml(caskName)} upgrade.\n`
-      );
       terminalOutput.scrollTop = terminalOutput.scrollHeight;
-      // Mark as "success" so the UI removes it from the list
-      ipcRenderer.send('upgrade-complete', { appName: caskName, success: true });
     } else {
       // Skip
       if (ipcRenderer.killPty) {

--- a/src/utils/__tests__/brew.test.ts
+++ b/src/utils/__tests__/brew.test.ts
@@ -179,15 +179,17 @@ describe('brew utilities', () => {
       );
     });
 
-    it('should return empty array on error', async () => {
-      mockExecAsync.mockRejectedValueOnce(new Error('brew command failed'));
+    it('should return empty array when both cask and formula lists fail', async () => {
+      mockExecAsync
+        .mockRejectedValueOnce(new Error('cask list failed'))
+        .mockRejectedValueOnce(new Error('formula list failed'));
 
       const result = await getInstalledApps();
 
       expect(result).toEqual([]);
     });
 
-    it('should handle errors from brew list --formula', async () => {
+    it('should still return casks when brew list --formula fails', async () => {
       mockExecAsync
         .mockResolvedValueOnce({
           stdout: 'cask1',
@@ -197,20 +199,23 @@ describe('brew utilities', () => {
 
       const result = await getInstalledApps();
 
-      expect(result).toEqual([]);
+      expect(result).toEqual([{ name: 'cask1', type: 'cask' }]);
     });
 
-    it('should handle errors from brew list --casks', async () => {
+    it('should still return formulas when brew list --casks fails', async () => {
       mockExecAsync
         .mockRejectedValueOnce(new Error('cask list failed'))
         .mockResolvedValueOnce({
-          stdout: 'formula1',
+          stdout: 'formula1 formula2',
           stderr: '',
         });
 
       const result = await getInstalledApps();
 
-      expect(result).toEqual([]);
+      expect(result).toEqual([
+        { name: 'formula1', type: 'formula' },
+        { name: 'formula2', type: 'formula' },
+      ]);
     });
 
     it('should preserve app names exactly as returned by brew', async () => {

--- a/src/utils/brew.ts
+++ b/src/utils/brew.ts
@@ -84,29 +84,40 @@ export async function getOutdatedApps(): Promise<OutdatedApp[]> {
   }
 }
 
+function parseBrewListOutput(stdout: string): string[] {
+  return stdout
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((name) => name.trim());
+}
+
 export async function getInstalledApps(): Promise<InstalledApp[]> {
   try {
     const env = getEnvWithBrewPath();
 
-    // Optimization: Parallelize fetching casks and formulas to significantly reduce I/O wait time
-    const [casksResult, formulasResult] = await Promise.all([
+    // Fetch casks and formulas independently so a cask-list failure (common on
+    // Linux / limited Homebrew installs) does not wipe the formula list.
+    const [casksSettled, formulasSettled] = await Promise.allSettled([
       execAsync('brew list --casks', { env }),
       execAsync('brew list --formula', { env }),
     ]);
 
-    // Get installed casks (brew list --casks returns space-separated list)
-    const installedCasks = casksResult.stdout
-      .trim()
-      .split(/\s+/)
-      .filter(Boolean)
-      .map((cask) => cask.trim());
+    const installedCasks =
+      casksSettled.status === 'fulfilled'
+        ? parseBrewListOutput(casksSettled.value.stdout)
+        : [];
+    if (casksSettled.status === 'rejected') {
+      console.error('[Brew] Error listing casks:', casksSettled.reason);
+    }
 
-    // Get installed formulas
-    const installedFormulas = formulasResult.stdout
-      .trim()
-      .split(/\s+/)
-      .filter(Boolean)
-      .map((formula) => formula.trim());
+    const installedFormulas =
+      formulasSettled.status === 'fulfilled'
+        ? parseBrewListOutput(formulasSettled.value.stdout)
+        : [];
+    if (formulasSettled.status === 'rejected') {
+      console.error('[Brew] Error listing formulas:', formulasSettled.reason);
+    }
 
     return [
       ...installedCasks.map((cask: string) => ({


### PR DESCRIPTION
## What

Lean Linux MVP for BrewMate: resilient brew package listing, non-macOS external-terminal handling, Ubuntu CI packaging dry-run, and Linux documentation. Builds on existing Linuxbrew PATH detection and electron-builder Linux targets.

## Acceptance criteria status

- [x] App launches on Linux (Ubuntu 22.04+ with Homebrew) without fatal errors — startup smoke on Linux CI; existing `--test-startup` path
- [x] Brew binary is detected via standard Linuxbrew paths — already in `path.ts` (unchanged; proven by tests)
- [x] Browse/search of available packages works — catalog fetch unchanged; install list no longer blanked by cask errors
- [x] Install and uninstall work for supported package types on Linux — formulas continue; cask list failures isolated in `brew.ts`
- [x] Services list works; UI does not imply launchd-only — existing “launchd / systemd” copy retained
- [x] Terminal/log output displays correctly — PTY path is cross-platform; external terminal soft-fails with guidance
- [x] App data/cache uses home-dir path (`~/.brewmate`) — already true (unchanged)
- [x] External-open actions do not hard-crash on Linux — `open-external-terminal` clear error + renderer catch
- [x] electron-builder produces Linux artifacts — existing AppImage/deb targets + CI `--linux --dir`
- [x] CI builds on a Linux runner — new `build-and-test-linux` job
- [x] README documents Linux prerequisites and install/build steps

## Approach

Follows the deep-review MVP: fix the real failure modes (all-or-nothing `brew list`, macOS-only external terminal throw), prove packaging on Ubuntu CI, document formula-primary Linux support. No platform abstraction layer, no multi-emulator terminal framework, no feature flags.

## What was deliberately NOT included

- Windows support
- Feature-flag rollout
- AppImage auto-update / apt repo / electron-updater
- Multi-distro CI matrix beyond `ubuntu-latest`
- `create-release.yml` Linux artifact publish
- New reveal-in-file-manager UI
- Changes to `path.ts` (already correct)
- New npm dependencies

## Documentation

- `README.md` — Linux prereqs, build, formula-primary note
- `package.json` description — macOS and Linux

## Test coverage

- Updated: `src/utils/__tests__/brew.test.ts` — partial list failure keeps formulas/casks
- Added: `src/main/__tests__/ptyManager.test.ts` — non-darwin external terminal soft-fail
- Full suite: **75 passing**

## Complexity guard status

- Complexity verdict: **lean** (preventative flags respected)
- Auto-generated files excluded: none staged; no lockfile churn; no `.dev/handoffs`

Closes #385

## Summary by Sourcery

Add initial Linux support for BrewMate across documentation, CI, and runtime behavior, ensuring Homebrew package listing and terminal interactions work robustly on non-macOS platforms.

New Features:
- Document Linux support, prerequisites, and build/install paths, and broaden app positioning to macOS and Linux.
- Enable Linux build artifacts via electron-builder and verify Linux startup in CI with a new Ubuntu workflow job.

Bug Fixes:
- Prevent failures in `brew list` cask or formula calls from blanking the entire installed app list by handling each list independently and tolerating partial errors.
- Ensure external terminal upgrades do not crash on non-macOS by soft-failing with a clear error and renderer messaging when external terminals are unsupported.

Enhancements:
- Refine external-terminal upgrade UX by reporting successful launches and guiding users toward the in-app terminal when external terminals are unavailable.

CI:
- Introduce a `build-and-test-linux` GitHub Actions job that installs Linux system dependencies, runs tests, builds the Electron app, packages Linux artifacts in dry-run mode, and performs a startup smoke test.

Documentation:
- Update README with Linux platform support, prerequisites, system packages, and Linux build instructions, and clarify macOS-specific first-launch steps.

Tests:
- Expand test coverage for brew listing error scenarios and add PTY manager tests verifying the non-macOS external-terminal soft-fail behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Linux support, including AppImage and `.deb` packaging options.
  - Added Linux setup guidance, prerequisites, installation instructions, and known limitations.

- **Bug Fixes**
  - Improved installed-app detection so available formulae or casks remain visible when the other source fails.
  - Improved external terminal failure handling with clearer errors and in-app terminal guidance.
  - Clarified that external terminal password entry is supported on macOS only.

- **Documentation**
  - Updated product and build documentation to reflect macOS and Linux availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->