### PR TITLE
feat: show third-party tap casks in Explore

### DIFF
--- a/src/main/ipcHandlers.ts
+++ b/src/main/ipcHandlers.ts
@@ -1,9 +1,9 @@
 import { ipcMain, IpcMainEvent, app } from 'electron';
 import { spawn, exec } from 'child_process';
+import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os'; // Import the 'os' module
 import { fetchJSON } from '../utils/fetchData';
-import { loadFromCache, saveToCache } from '../utils/cache';
+import { loadFromCache, saveToCache, getCachePath } from '../utils/cache';
 import { getTerminalPromptInfo } from '../utils/terminal';
 import { getInstalledApps, getOutdatedApps, getCacheSize, getAppDetails, scanVulnerabilities, getAllTapCaskNames, getThirdPartyCaskInfo } from '../utils/brew';
 import { logCommand, getLogFilePath } from '../utils/logger';
@@ -13,13 +13,10 @@ import { App, LoadingStatus } from '../types';
 import { t, changeLanguage, getCurrentLanguage } from './i18n';
 import categoriesData from '../data/categories';
 
-// Placeholder for ptyManager import. It will be loaded dynamically.
-let ptyManager: any;
-
 export function setupIpcHandlers(): void {
-  // Dynamically import ptyManager to avoid issues during initial setup if it's not needed
-  ptyManager = require('./ptyManager');
-  ptyManager.setupPtyIpcHandlers();
+  // Set up PTY IPC handlers for interactive cask upgrades
+  const { setupPtyIpcHandlers, startCaskUpgradePty } = require('./ptyManager');
+  setupPtyIpcHandlers();
   // Store latest outdated apps for batch upgrades
   let latestOutdated: Array<{ name: string; type: string }> = [];
 
@@ -499,7 +496,7 @@ export function setupIpcHandlers(): void {
       event.reply('upgrade-start', { appName: c.name });
 
       try {
-        await ptyManager.startCaskUpgradePty(c.name);
+        await startCaskUpgradePty(c.name);
         event.reply('upgrade-complete', { appName: c.name, success: true });
       } catch (err: any) {
         console.error('[IPC] PTY upgrade failed for', c.name, err);
@@ -545,15 +542,10 @@ export function setupIpcHandlers(): void {
       // After brew update succeeds, invalidate the apps cache so the next
       // get-all-apps request fetches fresh data from the Homebrew API.
       if (command.trim() === 'brew update' && code === 0) {
-        try {
-          const cachePath = path.join(os.homedir(), '.brewmate', 'apps-cache.json');
-          const fs = require('fs');
-          if (fs.existsSync(cachePath)) {
-            fs.unlinkSync(cachePath);
-          }
-        } catch (e) {
+        // Unlink is async and the cache may not exist yet — ignore deletion errors.
+        fs.promises.unlink(getCachePath()).catch(() => {
           // Ignore cache deletion errors
-        }
+        });
         event.reply('brew-update-complete');
       }
     });

--- a/src/main/ipcHandlers.ts
+++ b/src/main/ipcHandlers.ts
@@ -1,10 +1,11 @@
 import { ipcMain, IpcMainEvent, app } from 'electron';
 import { spawn, exec } from 'child_process';
 import * as path from 'path';
+import * as os from 'os'; // Import the 'os' module
 import { fetchJSON } from '../utils/fetchData';
 import { loadFromCache, saveToCache } from '../utils/cache';
 import { getTerminalPromptInfo } from '../utils/terminal';
-import { getInstalledApps, getOutdatedApps, getCacheSize, getAppDetails, scanVulnerabilities } from '../utils/brew';
+import { getInstalledApps, getOutdatedApps, getCacheSize, getAppDetails, scanVulnerabilities, getAllTapCaskNames, getThirdPartyCaskInfo } from '../utils/brew';
 import { logCommand, getLogFilePath } from '../utils/logger';
 import { getEnvWithBrewPath } from '../utils/path';
 import { HOMEBREW_CASKS_JSON_URL, HOMEBREW_FORMULAS_JSON_URL } from '../constants';
@@ -12,11 +13,13 @@ import { App, LoadingStatus } from '../types';
 import { t, changeLanguage, getCurrentLanguage } from './i18n';
 import categoriesData from '../data/categories';
 
-export function setupIpcHandlers(): void {
-  // Set up PTY IPC handlers for interactive cask upgrades
-  const { setupPtyIpcHandlers, startCaskUpgradePty } = require('./ptyManager');
-  setupPtyIpcHandlers();
+// Placeholder for ptyManager import. It will be loaded dynamically.
+let ptyManager: any;
 
+export function setupIpcHandlers(): void {
+  // Dynamically import ptyManager to avoid issues during initial setup if it's not needed
+  ptyManager = require('./ptyManager');
+  ptyManager.setupPtyIpcHandlers();
   // Store latest outdated apps for batch upgrades
   let latestOutdated: Array<{ name: string; type: string }> = [];
 
@@ -97,6 +100,65 @@ export function setupIpcHandlers(): void {
             type: 'formula' as const,
           })),
         ];
+
+        // Supplement with casks from third-party taps (not in the official API).
+        // brew search --casks queries ALL installed taps, so casks like
+        // "user/tap/caskname" that aren't on formulae.brew.sh still show up in Explore.
+        try {
+          const allTapCaskNames = await getAllTapCaskNames();
+          if (allTapCaskNames.length > 0) {
+            const apiCaskNames = new Set(
+              casks.map((c: any) => (c.token || c.name).toLowerCase())
+            );
+
+            // Casks in taps but missing from the official API list.
+            // Compare by short name (last path segment) but keep the
+            // tap-qualified name for `brew info --cask` lookups.
+            const missingCaskNames = allTapCaskNames.filter((name) => {
+              const shortName = name.split('/').pop()?.toLowerCase() || '';
+              return shortName && !apiCaskNames.has(shortName);
+            });
+
+            console.log(
+              `[IPC] Found ${missingCaskNames.length} casks from third-party taps`
+            );
+
+            if (missingCaskNames.length > 0) {
+              // Fetch details in parallel, chunked to avoid overwhelming brew
+              const chunkSize = 20;
+              for (let i = 0; i < missingCaskNames.length; i += chunkSize) {
+                const chunk = missingCaskNames.slice(i, i + chunkSize);
+                const results = await Promise.all(
+                  chunk.map(async (qualifiedName) => {
+                    const info = await getThirdPartyCaskInfo(qualifiedName);
+                    const shortName = qualifiedName.split('/').pop() || qualifiedName;
+                    if (info) {
+                      return {
+                        name: info.token || info.name || shortName,
+                        description: info.desc || '',
+                        homepage: info.homepage || '',
+                        version: info.version || 'N/A',
+                        type: 'cask' as const,
+                      };
+                    }
+                    // Info fetch failed — still add minimal entry so the cask shows up
+                    return {
+                      name: shortName,
+                      description: '',
+                      homepage: '',
+                      version: 'N/A',
+                      type: 'cask' as const,
+                    };
+                  })
+                );
+                allApps.push(...results);
+              }
+            }
+          }
+        } catch (tapError: any) {
+          console.error('[IPC] Error fetching third-party tap casks:', tapError.message);
+          // Don't fail the whole load — official API data is still valid
+        }
 
         // Save to cache
         saveToCache(allApps); // Optimization: Now async, runs in background to unblock main thread
@@ -437,7 +499,7 @@ export function setupIpcHandlers(): void {
       event.reply('upgrade-start', { appName: c.name });
 
       try {
-        await startCaskUpgradePty(c.name);
+        await ptyManager.startCaskUpgradePty(c.name);
         event.reply('upgrade-complete', { appName: c.name, success: true });
       } catch (err: any) {
         console.error('[IPC] PTY upgrade failed for', c.name, err);
@@ -479,6 +541,21 @@ export function setupIpcHandlers(): void {
     shell.on('close', (code) => {
       logCommand(command, output, code);
       event.reply('terminal-output', `\nProcess exited with code ${code}\n`);
+
+      // After brew update succeeds, invalidate the apps cache so the next
+      // get-all-apps request fetches fresh data from the Homebrew API.
+      if (command.trim() === 'brew update' && code === 0) {
+        try {
+          const cachePath = path.join(os.homedir(), '.brewmate', 'apps-cache.json');
+          const fs = require('fs');
+          if (fs.existsSync(cachePath)) {
+            fs.unlinkSync(cachePath);
+          }
+        } catch (e) {
+          // Ignore cache deletion errors
+        }
+        event.reply('brew-update-complete');
+      }
     });
   });
 

--- a/src/main/ipcHandlers.ts
+++ b/src/main/ipcHandlers.ts
@@ -535,15 +535,16 @@ export function setupIpcHandlers(): void {
       event.reply('terminal-output', dataStr);
     });
 
-    shell.on('close', (code) => {
+    shell.on('close', async (code) => {
       logCommand(command, output, code);
       event.reply('terminal-output', `\nProcess exited with code ${code}\n`);
 
       // After brew update succeeds, invalidate the apps cache so the next
       // get-all-apps request fetches fresh data from the Homebrew API.
       if (command.trim() === 'brew update' && code === 0) {
-        // Unlink is async and the cache may not exist yet — ignore deletion errors.
-        fs.promises.unlink(getCachePath()).catch(() => {
+        // Await deletion so the renderer can't re-read the stale cache before
+        // it's gone. The cache may not exist yet — ignore deletion errors.
+        await fs.promises.unlink(getCachePath()).catch(() => {
           // Ignore cache deletion errors
         });
         event.reply('brew-update-complete');

--- a/src/main/ptyManager.ts
+++ b/src/main/ptyManager.ts
@@ -57,8 +57,8 @@ export async function startCaskUpgradePty(caskName: string): Promise<{ code: num
       }
     });
 
-    activePty.onExit(({ exitCode }) => {
-      const code = exitCode ?? 0;
+    activePty.onExit((exitInfo: { exitCode: number }) => {
+      const code = exitInfo.exitCode ?? 0;
       sendToRenderer('pty-exit', { cask: caskName, code });
       activePty = null;
       resolve({ code });

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -47,6 +47,7 @@ const validReceiveChannels = [
   'pty-data',
   'cask-sudo-required',
   'pty-exit',
+  'brew-update-complete',
 ];
 
 contextBridge.exposeInMainWorld('electronAPI', {

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -807,6 +807,12 @@ function setupIpcListeners(): void {
     filterApps();
   });
 
+  ipcRenderer.on('brew-update-complete', () => {
+    console.log('[Renderer] Brew update complete, refreshing app data...');
+    ipcRenderer.send('get-all-apps');
+    ipcRenderer.send('get-installed-apps');
+  });
+
   ipcRenderer.on('installed-apps-error', (_event: any, errorMessage: string) => {
     console.error('[Renderer] Error getting installed apps:', errorMessage);
   });

--- a/src/utils/__tests__/brew.test.ts
+++ b/src/utils/__tests__/brew.test.ts
@@ -337,10 +337,23 @@ describe('brew utilities', () => {
       });
 
       const result = await getAllTapCaskNames();
-
       expect(result).toEqual([
         'firefox',
         'romankurnovskii/awesome-brew/orca',
+      ]);
+    });
+
+    it('should skip brew warning/error/note lines', async () => {
+      mockExecAsync.mockResolvedValueOnce({
+        stdout:
+          'Warning: some upgrade notice\nfirefox\nError: something failed\nromankurnovskii/awesome-brew/etemaro\nNote: run brew update',
+        stderr: '',
+      });
+
+      const result = await getAllTapCaskNames();
+      expect(result).toEqual([
+        'firefox',
+        'romankurnovskii/awesome-brew/etemaro',
       ]);
     });
 

--- a/src/utils/__tests__/brew.test.ts
+++ b/src/utils/__tests__/brew.test.ts
@@ -1,4 +1,4 @@
-import { getInstalledApps, getOutdatedApps, getCacheSize } from '../brew';
+import { getInstalledApps, getOutdatedApps, getCacheSize, getAllTapCaskNames, getThirdPartyCaskInfo } from '../brew';
 import { getEnvWithBrewPath } from '../path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
@@ -311,6 +311,91 @@ describe('brew utilities', () => {
       mockExecAsync.mockRejectedValueOnce(new Error('brew failed'));
       const result = await getOutdatedApps();
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('getAllTapCaskNames', () => {
+    it('should return all cask names from all taps', async () => {
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: 'firefox\ngoogle-chrome\nromankurnovskii/awesome-brew/etemaro',
+        stderr: '',
+      });
+
+      const result = await getAllTapCaskNames();
+
+      expect(result).toEqual([
+        'firefox',
+        'google-chrome',
+        'romankurnovskii/awesome-brew/etemaro',
+      ]);
+    });
+
+    it('should strip section headers from output', async () => {
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: '==> Casks\nfirefox\nromankurnovskii/awesome-brew/orca\n==> Formulae\nsome-formula',
+        stderr: '',
+      });
+
+      const result = await getAllTapCaskNames();
+
+      expect(result).toEqual([
+        'firefox',
+        'romankurnovskii/awesome-brew/orca',
+      ]);
+    });
+
+    it('should return empty array on error', async () => {
+      mockExecAsync.mockRejectedValueOnce(new Error('brew search failed'));
+      const result = await getAllTapCaskNames();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getThirdPartyCaskInfo', () => {
+    it('should return cask info for a tap-qualified cask name', async () => {
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          casks: [
+            {
+              token: 'etemaro',
+              name: ['EteMaro'],
+              desc: 'A cask from a third-party tap',
+              homepage: 'https://example.com',
+              version: '1.2.3',
+            },
+          ],
+        }),
+        stderr: '',
+      });
+
+      const result = await getThirdPartyCaskInfo('romankurnovskii/awesome-brew/etemaro');
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          token: 'etemaro',
+          desc: 'A cask from a third-party tap',
+        })
+      );
+      expect(mockExecAsync).toHaveBeenCalledWith(
+        'brew info --cask --json=v2 romankurnovskii/awesome-brew/etemaro',
+        expect.anything()
+      );
+    });
+
+    it('should return null when no casks in response', async () => {
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: JSON.stringify({ casks: [] }),
+        stderr: '',
+      });
+
+      const result = await getThirdPartyCaskInfo('unknown-cask');
+      expect(result).toBeNull();
+    });
+
+    it('should return null on error', async () => {
+      mockExecAsync.mockRejectedValueOnce(new Error('brew info failed'));
+      const result = await getThirdPartyCaskInfo('unknown-cask');
+      expect(result).toBeNull();
     });
   });
 });

--- a/src/utils/brew.ts
+++ b/src/utils/brew.ts
@@ -157,6 +157,64 @@ export async function getAppDetails(appName: string, type: 'cask' | 'formula'): 
   }
 }
 
+/**
+ * Fetch all cask names available from ALL installed taps (including third-party taps).
+ * Uses `brew search --casks` which queries every tap, not just homebrew-cask.
+ * Returns the raw names as reported by brew. Names from third-party taps may be
+ * tap-qualified (e.g. "user/tap/caskname") — the caller can strip the prefix for
+ * display but should keep it for `brew info --cask` lookups.
+ */
+export async function getAllTapCaskNames(): Promise<string[]> {
+  try {
+    const env = getEnvWithBrewPath();
+    const { stdout } = await execAsync('brew search --casks', { env });
+    const names: string[] = [];
+    // With --casks, brew should only emit cask names. Track section headers
+    // defensively so a "==> Formulae" section can never leak formula names in.
+    let inCasksSection = true;
+    for (const line of stdout.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      if (trimmed.startsWith('==>')) {
+        inCasksSection = trimmed.toLowerCase().includes('cask');
+        continue;
+      }
+      if (inCasksSection) {
+        names.push(
+          ...trimmed
+            .split(/\s+/)
+            .filter(Boolean)
+            .map((name) => name.trim())
+        );
+      }
+    }
+    return names;
+  } catch (error) {
+    console.error('[Brew] Error fetching tap cask names:', error);
+    return [];
+  }
+}
+
+/**
+ * Fetch details for a single cask that exists only in a third-party tap
+ * (not in the official Homebrew API).
+ * Uses `brew info --cask --json=v2` to get name, desc, homepage, and version.
+ */
+export async function getThirdPartyCaskInfo(caskName: string): Promise<any | null> {
+  try {
+    const env = getEnvWithBrewPath();
+    const { stdout } = await execAsync(`brew info --cask --json=v2 ${caskName}`, { env });
+    const data = JSON.parse(stdout);
+    if (data.casks && data.casks.length > 0) {
+      return data.casks[0];
+    }
+    return null;
+  } catch (error) {
+    // Cask info not available — skip silently
+    return null;
+  }
+}
+
 export async function scanVulnerabilities(): Promise<any[]> {
   try {
     const env = getEnvWithBrewPath();

--- a/src/utils/brew.ts
+++ b/src/utils/brew.ts
@@ -175,6 +175,8 @@ export async function getAllTapCaskNames(): Promise<string[]> {
     for (const line of stdout.split('\n')) {
       const trimmed = line.trim();
       if (!trimmed) continue;
+      // Skip brew notices (upgrade warnings, errors, etc.) — they are not cask names.
+      if (/^(Warning|Error|Note):/i.test(trimmed)) continue;
       if (trimmed.startsWith('==>')) {
         inCasksSection = trimmed.toLowerCase().includes('cask');
         continue;


### PR DESCRIPTION
## Summary

The Explore page only listed apps from the official Homebrew APIs (`formulae.brew.sh/api/cask.json` + `formula.json`). Casks installed from **locally added third-party taps** (e.g. `romankurnovskii/awesome-brew/etemaro`) never appeared in the GUI and couldn't be installed from it.

This PR makes Explore tap-aware:

1. **`get-all-apps`** now merges casks found via `brew search --casks` (which covers all installed taps) that are missing from the official `cask.json` API. Their info is fetched with `brew info --cask --json=v2` in parallel chunks (size 20), comparing by short name while looking up with the tap-qualified name.
2. **`execute-command`** deletes `~/.brewmate/apps-cache.json` and emits `brew-update-complete` when `brew update` exits 0 — so clicking "brew update" in the GUI invalidates the stale cache and the Explore page refreshes with newly added tap casks immediately, without restarting.
3. **Renderer** listens for `brew-update-complete` and re-requests the app lists.

Casks resolve by bare name across all installed taps in Homebrew, so the existing Install button works for third-party tap casks without changes.

## Changes

| File | Change |
|------|--------|
| `src/main/ipcHandlers.ts` | Cache invalidation + `brew-update-complete` emission; third-party tap merge in `get-all-apps` |
| `src/utils/brew.ts` | Added `getAllTapCaskNames()` and `getThirdPartyCaskInfo()` |
| `src/preload/preload.ts` | Added `brew-update-complete` receive channel |
| `src/renderer/renderer.ts` | Listens for `brew-update-complete` → refreshes app lists |
| `src/main/ptyManager.ts` | Fixed TS7031 by typing the `onExit` callback |
| `src/utils/__tests__/brew.test.ts` | 6 new tests for the tap helpers |

## Testing

- `npm run build` — passes, no TS errors
- `npx jest` — 80/80 tests passing across 7 suites

## Notes / scope

- Covers **casks** from third-party taps. Third-party tap **formulae** (e.g. `romankurnovskii/awesome-brew/surfpool`) are not yet covered — they need tap-qualified names in the install command, which is a follow-up.

## Summary by Sourcery

Extend Explore to include casks from all installed taps and keep its data fresh after brew updates.

New Features:
- Include third-party tap casks in the Explore apps list by merging search results with the official Homebrew cask API.
- Expose brew-update completion events to the renderer so the UI can automatically refresh app and installed lists.

Enhancements:
- Dynamically load the PTY manager and forward cask upgrade requests through the shared instance.
- Improve PTY exit handling by typing the onExit callback to satisfy TypeScript.

Tests:
- Add unit tests for fetching tap cask names and third-party cask info from brew search/info output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App catalogs now include available third-party Homebrew casks.
  * Application data refreshes automatically after Homebrew updates complete.

* **Bug Fixes**
  * Third-party tap lookup failures no longer prevent official app listings from loading.
  * Missing or incomplete cask details now receive fallback handling.

* **Tests**
  * Added coverage for Homebrew tap discovery, metadata parsing, empty results, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->