### PR TITLE
fix(cask): correct 1.0.34 sha256 for universal dmg

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -5,7 +5,7 @@ cask "brewmate" do
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 'd1938fd5d32aef6e7144d1cb5431c0ba7ccd1657d81947dab46828c59175128c'
+  sha256 'a5a7c21a98dd8911ef2d9daa93fa71625531cdb33c1d1f65d67783ded9cf6711'
 
   auto_updates true
 


### PR DESCRIPTION
The 1.0.34 cask was bumped to the sha256 of the .zip release asset (d1938fd...) while the URL points to the .dmg asset. Correct it to the DMG's sha256 (a5a7c21a...), verified by downloading the release asset. Fixes the brew install --cask brewmate checksum failure.

## Summary by Sourcery

Bug Fixes:
- Fix the BrewMate 1.0.34 Homebrew cask SHA256 so it matches the downloaded DMG and resolves checksum failures.