### PR TITLE
fix: exclude node-pty prebuilds from universal mac build

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -18,6 +18,7 @@ files:
   - 'node_modules/**/*'
   - 'package.json'
   - '!**/src/**/*'
+  - '!**/node_modules/node-pty/prebuilds/**'
   - '!**/*.{iml,o,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,xproj}'
   - '!.editorconfig'
   - '!**/._*'

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -87,13 +87,16 @@ describe('electron-builder.yml', () => {
     expect(hasExclusion).toBe(false);
   });
 
-  it('node_modules should not be excluded anywhere in the files section', () => {
-    // Any variant that explicitly excludes node_modules would break the bundle
-    const nodeModulesExclusionPattern = /!\*\*\/node_modules/;
-    const hasAnyNodeModulesExclusion = lines.some((l) =>
-      nodeModulesExclusionPattern.test(l)
+  it('node_modules should not be excluded wholesale from the files section', () => {
+    // The bundle needs node_modules included; a bare !**/node_modules exclusion
+    // (e.g. !**/node_modules/**/*) would break it. Targeted exclusions of a
+    // specific package subdirectory (node-pty prebuilds, which are only a
+    // runtime fallback and are rebuilt per-arch into build/Release) are allowed.
+    const nodeModulesWholesaleExclusion = /!\*\*\/node_modules(?:\/\*\*(?:\/\*)?|\/)\s*$/;
+    const hasWholesaleExclusion = lines.some((l) =>
+      nodeModulesWholesaleExclusion.test(l.trim())
     );
-    expect(hasAnyNodeModulesExclusion).toBe(false);
+    expect(hasWholesaleExclusion).toBe(false);
   });
 
   // -- Regressions: existing file patterns should be preserved ---------------


### PR DESCRIPTION
Fixes the Release workflow failure:

- @electron/universal aborts the x64+arm64 merge with: Detected file .../node-pty/prebuilds/darwin-arm64/pty.node that's the same in both x64 and arm64 builds and not covered by the x64ArchFiles rule.
- node-pty's bundled prebuilds are a runtime fallback only; loadNativeModule (lib/utils.js) tries build/Release first, which electron-builder rebuilds per-arch for the Electron ABI. Excluding prebuilds is safe and lets the universal merge complete.
- Verified locally: electron-builder --mac --universal --dir now succeeds, pty.node is unpacked, and the startup smoke test exits 0.

## Summary by Sourcery

Build:
- Update electron-builder configuration to omit node-pty prebuild artifacts from packaged files for macOS.