### PR TITLE
fix: smoke test the universal mac build, not the host-arch staging app

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -44,9 +44,19 @@ jobs:
           TEST_STARTUP: 'true'
           ELECTRON_ENABLE_LOGGING: '1'
         run: |
-          ASAR_PATH=$(find dist-app -name "app.asar" | head -n 1)
+          # Smoke-test the universal build that ships in the DMG/ZIP.
+          # Do NOT use `find | head -1`: it can pick a host-arch staging app
+          # (dist-app/mac) whose native addon was never rebuilt for Electron.
+          if [ -f "dist-app/mac-universal/BrewMate.app/Contents/Resources/app.asar" ]; then
+            ASAR_PATH="dist-app/mac-universal/BrewMate.app/Contents/Resources/app.asar"
+          else
+            ASAR_PATH=$(find dist-app -path "*mac-universal*" -name app.asar | head -n 1)
+          fi
           if [ -z "$ASAR_PATH" ]; then
-            echo "Error: app.asar not found!"
+            echo "Error: universal app.asar not found!"
+            echo "--- dist-app contents ---"
+            ls -la dist-app || true
+            find dist-app -name "app.asar" 2>/dev/null || true
             exit 1
           fi
           echo "Found ASAR at: $ASAR_PATH"


### PR DESCRIPTION
The Release workflow's Verify Startup (Smoke Test) step used `find dist-app -name app.asar | head -n 1`, which picked `dist-app/mac/BrewMate.app` (a host-arch staging app) instead of `dist-app/mac-universal/BrewMate.app`. The staging app's node-pty native addon was never rebuilt for Electron, so the app crashed with `Failed to load native module: pty.node` and the step timed out after 2 minutes — failing the 1.0.35 release at the last step before asset upload.

Fix: target `dist-app/mac-universal/BrewMate.app/Contents/Resources/app.asar` explicitly (fallback: find by `*mac-universal*`), with clear error output listing dist-app if missing. The universal app is the one that ships in the DMG/ZIP and was verified working locally (startup smoke test exits 0).

## Summary by Sourcery

CI:
- Update the Verify Startup step to explicitly locate the universal mac app.asar, with a fallback search scoped to mac-universal paths and improved error diagnostics when missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS release verification by checking the universal application package explicitly.
  * Enhanced failure messages with clearer artifact details and build-output diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->