### PR TITLE
fix: prevent electron-builder auto-publish conflict in linux build

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -171,8 +171,10 @@ jobs:
         working-directory: .
 
       - name: Build Linux App
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Do NOT pass GITHUB_TOKEN here: it makes electron-builder try to
+        # auto-publish, which fails when the release already exists (the
+        # create-release job creates it, and the upload step below attaches
+        # assets via softprops/action-gh-release).
         run: npm run build:linux
         working-directory: .
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -150,8 +150,9 @@ jobs:
           git config user.name "R K"
           git config user.email "email@example.com"
           git add Casks/brewmate.rb
-          git commit -m "chore: update cask to version ${VERSION} [skip ci]"
-          git push origin main
+          # Only commit if the cask actually changed (safe to re-run)
+          git diff --cached --quiet || git commit -m "chore: update cask to version ${VERSION} [skip ci]"
+          git push origin main || true
 
   build-linux:
     needs: create-release


### PR DESCRIPTION
The build-linux job failed because GITHUB_TOKEN was set in the Build Linux App step, making electron-builder try to auto-publish to GitHub. Since the create-release job already created the release, electron-builder hit: 'existing type not compatible with publishing type tag=v1.0.35 existingType=release publishingType=draft'. Removed the token from the build step; the upload step (softprops/action-gh-release) handles asset publishing separately.

## Summary by Sourcery

CI:
- Update the create-release workflow to build the Linux app without GITHUB_TOKEN to prevent electron-builder auto-publish conflicts with the separate release job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Linux release build process to prevent unintended automatic publishing.
  * Release assets continue to be uploaded separately as part of the release workflow.
  * Automated updates now create commits only when changes are present and continue gracefully if publishing encounters an issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->