### PR TITLE
fix: disable electron-builder auto-publish for linux build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:mac:universal": "./scripts/build-direct-universal.sh",
     "build:mac:arm64": "npm run build && electron-builder --mac --arm64",
     "build:mac:x64": "npm run build && electron-builder --mac --x64",
-    "build:linux": "npm run build && electron-builder --linux",
+    "build:linux": "npm run build && electron-builder --linux --publish=never",
     "build:mas": "./scripts/build-mas-universal.sh",
     "pre-submit": "echo 'Pre-submit check not implemented yet'",
     "dist": "npm run build && electron-builder --mac",


### PR DESCRIPTION
The build-linux job was failing because electron-builder tried to auto-publish to GitHub (detecting GITHUB_TOKEN in env), but hit a conflict with the existing release (created by the mac job). Added --publish=never to disable this.