### PR TITLE
fix: add author email for Linux .deb package build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "brewmate",
   "version": "1.0.36",
   "description": "BrewMate - A modern Homebrew package manager GUI for macOS and Linux",
-  "author": "Roman Kurnovskii",
+  "author": {
+    "name": "Roman Kurnovskii",
+    "email": "romankurnovskii@gmail.com"
+  },
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc && npm run build:renderer && npm run copy:static",


### PR DESCRIPTION
electron-builder requires an author.email field in package.json to build .deb packages. Without it, the build-linux step fails with: 'Please specify author email in the application package.json'. Added email to the author field.